### PR TITLE
log: Allow debugging early via env var

### DIFF
--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -108,3 +108,7 @@ Uniform Logging
 ^^^^^^^^^^^^^^^
 
 The ``gluetool`` framework provides uniform logging. Modules can use their own ``info``, ``warn``, ``debug`` and ``verbose`` methods to log messages on different log levels. The log level can be changed using the ``-d/--debug`` and ``-v/--verbose`` options of the ``gluetool`` command.
+
+  .. note::
+
+    Note that the ``-d/--debug`` and ``-v/--verbose`` options will enable the logging after parsing the command line and configuration. To enable the debug mode as early as possible, i.e. during the initialization of the logging system, export the variable ``GLUETOOL_DEBUG`` to any value.

--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -40,6 +40,7 @@ Example usage:
 import atexit
 import json
 import logging
+import os
 import traceback
 
 import jinja2
@@ -50,6 +51,8 @@ from .color import Colors
 BLOB_HEADER = '---v---v---v---v---v---'
 BLOB_FOOTER = '---^---^---^---^---^---'
 
+# Default log level is logging.INFO or logging.DEBUG if GLUETOOL_DEBUG environment variable is set
+DEFAULT_LOG_LEVEL = logging.DEBUG if os.getenv('GLUETOOL_DEBUG') else logging.INFO
 
 # Add our custom "verbose" loglevel - it's even bellow DEBUG
 logging.VERBOSE = 5
@@ -473,7 +476,7 @@ class Logging(object):
         return Logging.logger
 
     @staticmethod
-    def create_logger(output_file=None, level=logging.INFO, sentry=None, sentry_submit_warning=None):
+    def create_logger(output_file=None, level=DEFAULT_LOG_LEVEL, sentry=None, sentry_submit_warning=None):
         """
         Create and setup logger.
 


### PR DESCRIPTION
By setting the GLUETOOL_DEBUG variable to any value.

Changelog: gluetool now supports early debugging by setting the GLUETOOL_DEBUG environment variable.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>