### PR TITLE
logging: when logging exception traceback, log locals of each frame

### DIFF
--- a/gluetool/tests/test_log_exception.py
+++ b/gluetool/tests/test_log_exception.py
@@ -1,0 +1,93 @@
+import re
+import sys
+
+import jinja2
+import pytest
+
+import gluetool
+import gluetool.log
+
+
+EXPECTED = jinja2.Template(r"""---v---v---v---v---v--- Exception: ---v---v---v---v---v---
+
+gluetool.glue.GlueError: Foo failed
+
+
+  File "{{ FILE }}", line 83, in test_sanity
+    foo\(\)
+
+    Local variables:
+        exc = Foo failed
+        excinfo = \(<class 'gluetool\.glue\.GlueError'>, GlueError\('Foo failed',\), <traceback object at 0x[0-9a-f]+>\)
+
+  File "{{ FILE}}", line 77, in foo
+    raise gluetool.GlueError\('Foo failed'\)
+
+    Local variables:
+
+---\^---\^---\^---\^---\^---\^----------\^---\^---\^---\^---\^---\^---
+
+---v---v---v---v---v--- Caused by: ---v---v---v---v---v---
+
+exceptions.ValueError: Z is really lame value
+
+
+  File "{{ FILE }}", line 74, in foo
+    return bar\(17\)
+
+    Local variables:
+
+  File "{{ FILE }}", line 69, in bar
+    return baz\(13, p\)
+
+    Local variables:
+        p = 17
+
+  File "{{ FILE }}", line 65, in baz
+    raise ValueError\('Z is really lame value'\)
+
+    Local variables:
+        x = 13
+        y = 17
+        z = 13
+
+---\^---\^---\^---\^---\^---\^----------\^---\^---\^---\^---\^---\^---
+""").render(FILE=__file__)
+
+
+# Raise exception from a frame deeper in the stack, catch it and raise another
+# to establish exception chain. Spice the functions with local variables, to give
+# us something to check in the output.
+
+def baz(x, y):
+    z = x
+
+    raise ValueError('Z is really lame value')
+
+
+def bar(p):
+    return baz(13, p)
+
+
+def foo():
+    try:
+        return bar(17)
+
+    except ValueError:
+        raise gluetool.GlueError('Foo failed')
+
+
+def test_sanity():
+    # not using pytest.raises, don't want pytest to spoil our exception with its smart stuff
+    try:
+        foo()
+
+    except gluetool.GlueError as exc:
+        excinfo = sys.exc_info()
+
+    # not assigning output of formatter to a local variable, we don't want it to appear in the top-level
+    # frame's list of locals, leading to a self-reference in expected output.
+
+    # match lines one by one, using expected as a regex pattern
+    for l1, l2 in zip(EXPECTED.split('\n'), gluetool.log.LoggingFormatter._format_exception_chain(excinfo).split('\n')):
+        assert re.match('^' + l1 + '$', l2)


### PR DESCRIPTION
Not using traceback.format_tb any more, formatting the whole traceback
on our own to get more control over it, and adding locals for each
frame. It's very crude, using str/repr internally to format objects, but
let's not be too smart in the first patch.