### PR TITLE
logging: add missing helpers for formatting blobs and XML elements

### DIFF
--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -173,6 +173,14 @@ class BlobLogger(object):
             return self.on_finally(*args, **kwargs)
 
 
+def format_blob(blob):
+    """
+    Format a blob of text for printing. Wraps the text with boundaries to mark its borders.
+    """
+
+    return '{}\n{}\n{}'.format(BLOB_HEADER, blob, BLOB_FOOTER)
+
+
 def format_dict(dictionary):
     """
     Format a Python data structure for printing. Uses :py:func:`json.dumps` formatting
@@ -185,6 +193,16 @@ def format_dict(dictionary):
         return repr(obj)
 
     return json.dumps(dictionary, sort_keys=True, indent=4, separators=(',', ': '), default=default)
+
+
+def format_xml(element):
+    """
+    Format an XML element, e.g. Beaker job description, for printing.
+
+    :param element: XML element to format.
+    """
+
+    return element.prettify(encoding='utf-8')
 
 
 def log_dict(writer, intro, data):
@@ -239,7 +257,7 @@ def log_blob(writer, intro, blob):
     :param str blob: The actual blob of text.
     """
 
-    writer("{}:\n{}\n{}\n{}".format(intro, BLOB_HEADER, blob, BLOB_FOOTER))
+    writer("{}:\n{}".format(intro, format_blob(blob)))
 
 
 def log_xml(writer, intro, element):
@@ -251,7 +269,7 @@ def log_xml(writer, intro, element):
     :param element: XML element to log.
     """
 
-    writer("{}:\n{}".format(intro, element.prettify(encoding='utf-8')))
+    writer("{}:\n{}".format(intro, format_xml(element)))
 
 
 class ContextAdapter(logging.LoggerAdapter):

--- a/gluetool/tests/test_logging.py
+++ b/gluetool/tests/test_logging.py
@@ -1,0 +1,36 @@
+import json
+import re
+import string
+
+import pytest
+from hypothesis import assume, given, strategies as st
+
+import gluetool.log
+
+# strategy to generate strctured data
+_structured = st.recursive(st.none() | st.booleans() | st.floats(allow_nan=False) | st.text(string.printable),
+                           lambda children: st.lists(children) | st.dictionaries(st.text(string.printable), children))
+
+
+@given(blob=st.text(alphabet=string.printable + string.whitespace))
+def test_format_blob(blob):
+    pattern = r"""^{}$
+{}
+^{}$""".format(re.escape(gluetool.log.BLOB_HEADER),
+               re.escape(blob),
+               re.escape(gluetool.log.BLOB_FOOTER))
+
+    re.match(pattern, gluetool.log.format_blob(blob), re.MULTILINE)
+
+
+@given(data=_structured)
+def test_format_dict(data):
+    # This is what format_dict does... I don't have other way to generate similar to output to match format_dict
+    # with other code. Therefore this is more like a sanity test, checking that format_dict does some formatting,
+    # ignoring how its output actually looks.
+    def default(obj):
+        return repr(obj)
+
+    expected = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '), default=default)
+
+    assert re.match(re.escape(expected), gluetool.log.format_dict(data), re.MULTILINE)


### PR DESCRIPTION
For the sake of completeness, provide these helpers as well.