### PR TITLE
Document context help

### DIFF
--- a/gluetool/tests/test_help.py
+++ b/gluetool/tests/test_help.py
@@ -1,0 +1,52 @@
+import pytest
+
+import gluetool.glue
+import gluetool.help
+
+
+def do_test_extract_eval_context_info(source_class, expected):
+    assert gluetool.help.extract_eval_context_info(source_class()) == expected
+
+
+def test_extract_eval_context_info():
+    expected_context_info = {
+        'some variable': 'and its description'
+    }
+
+    class DummyModule(object):
+        name = 'dummy-module'
+
+        @property
+        def eval_context(self):
+            # Cannot assign __content__ == expected_context_info since extract_eval_context_info detects
+            # __content__ = {, not just any generic assignment.
+
+            __content__ = {
+                'some variable': 'and its description'
+            }
+
+            return {}
+
+    do_test_extract_eval_context_info(DummyModule, expected_context_info)
+
+
+def test_extract_eval_context_info_missing():
+    class DummyModule(object):
+        name = 'dummy-module'
+
+        @property
+        def eval_context(self):
+            return {}
+
+    do_test_extract_eval_context_info(DummyModule, {})
+
+
+def test_extract_eval_context_info_unchanged():
+    class DummyModule(gluetool.glue.Configurable):
+        name = 'dummy-module'
+
+        @property
+        def eval_context(self):
+            return {}
+
+    do_test_extract_eval_context_info(DummyModule, {})

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
               'ruamel.yaml==0.15.34',
               'Sphinx==1.5.2',
               'sphinx-rtd-theme==0.1.9',
-              'tabulate==0.7.7',
+              'tabulate==0.8.2',
               'urlnorm==1.1.4'
           ],
           description='Python framework for constructing command-line pipelines',


### PR DESCRIPTION
`gluetool -E`:

```
** Variables available in eval context **

Variable    Module name    Description
----------  -------------  ----------------------------------------------
ENV         gluetool core  Dictionary representing environment variables.
```

Also, eval context is part of module help, just like we add shared functions:

```
...

** Evaluation context **

  * JENKINS_JOB_NAME

    Name of the Jenkins job the build running this module belongs to. If it cannot be determined, the value is
    None. JOB_NAME environment variable is the primary source of this information.

  * JENKINS_BUILD_ID

    ID ("number") of the Jenkins build running this module, within its parent job. If it cannot be determined, the
    value is None. BUILD_ID environment variable is the primary source of this value.

  * JENKINS_URL

    URL of the Jenkins server running this module. If it cannot be determined, the value is None.
    JENKINS_URL environment variable is the primary source of this information.

  * JENKINS_BUILD_URL

    URL of the Jenkins build running this module. If it cannot be determined, the value is None.
    BUILD_URL environment variable is the primary source of this value.

  * JENKINS_JOB_URL

    URL of the Jenkins job the build running this module belongs to. If it cannot be determined, the value is
    None. JOB_URL environment variable is the primary source of this information.
