### PR TITLE
@shared_function decorator

### DIFF
--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -88,7 +88,7 @@ Below is an example of configuration for this ``openstack`` module.
 Shared Functions
 ^^^^^^^^^^^^^^^^
 
-Shared functions are the only way how modules can share data to the subsequent modules on the command-line pipeline. Each module can define a shared function via the :py:attr:`shared_functions <gluetool.glue.Module.shared_functions>` list. The available shared functions then can be easily called from any subsequent module being executed via the :py:meth:`shared <gluetool.glue.Module.shared>` method.
+Shared functions are the only way how modules can share data to the subsequent modules on the command-line pipeline. Each module can expose its shared functions by by decorating its methods by :py:attr:`shared_functions <gluetool.shared_function>` decorator. The available shared functions then can be easily called from any subsequent module being executed via the :py:meth:`shared <gluetool.glue.Module.shared>` method.
 
 To list all shared functions provided by the available modules, use the gluetool's `-L` option
 

--- a/docs/source/howto-modules.rst
+++ b/docs/source/howto-modules.rst
@@ -64,7 +64,7 @@ Shared functions
 
 See the :ref:`framework's documentation <shared-functions>` for introduction into shared functions.
 
-A module can define any number of shared functions by listing their name as a string in the :py:attr:`gluetool.glue.Module.shared_functions <shared_functions>` list. The shared functions are made available to other modules after the module has been executed. This makes it possible for the module to redefine the previously defined shared functions with their own version.
+A module can define any number of shared functions by decorating its methods with :py:func:`gluetool.shared_function` decorator. The shared functions are made available to other modules after the module has been executed. This makes it possible for the module to redefine the previously defined shared functions with their own version.
 
 Here is an example of a simple module that exposes myapi shared function and takes one optional argument specifying the api version.
 
@@ -75,8 +75,7 @@ Here is an example of a simple module that exposes myapi shared function and tak
     class MyApiModule(gluetool.Module):
         name = 'myapi'
 
-        shared_functions = ['myapi']
-
+        @gluetool.shared_function
         def myapi(self, api_version=1):
             return 'My Api version: {}'.format(api_version)
 
@@ -108,8 +107,8 @@ For example, imagine two "publishing" modules - one sends messages to "alpha", t
 
     class PublishAlpha(gluetool.Module):
         name = 'publish-alpha'
-        shared_functions = ['publish']
 
+        @gluetool.shared_function
         def publish(self, message):
             self.info("publishing to alpha '{}'".format(message))
             self.overloaded_shared('publish', message)
@@ -120,8 +119,8 @@ For example, imagine two "publishing" modules - one sends messages to "alpha", t
 
     class PublishOmega(gluetool.Module):
         name = 'publish-omega'
-        shared_functions = ['publish']
 
+        @gluetool.shared_function
         def publish(self, message):
             self.info("publishing to omega '{}'".format(message))
             self.overloaded_shared('publish', message)

--- a/gluetool/__init__.py
+++ b/gluetool/__init__.py
@@ -1,7 +1,7 @@
-from .glue import Glue, Module
+from .glue import Glue, Module, shared_function
 from .glue import GlueError, SoftGlueError, GlueRetryError, GlueCommandError, Failure
 from . import utils
 
-__all__ = ['Glue', 'Module',
+__all__ = ['Glue', 'Module', 'shared_function',
            'GlueError', 'SoftGlueError', 'GlueRetryError', 'GlueCommandError', 'Failure',
            'utils']

--- a/gluetool/tests/__init__.py
+++ b/gluetool/tests/__init__.py
@@ -75,12 +75,12 @@ class CaplogWrapper(object):
         return matcher(_cmp(record) for record in self.records)
 
 
-def create_module(module_class, glue=None, glue_class=NonLoadingGlue, name='dummy-module', add_shared=True):
+def create_module(module_class, glue=None, glue_class=NonLoadingGlue, name='dummy-module', register_shared=True):
     glue = glue or glue_class()
     mod = module_class(glue, name)
 
-    if add_shared is True:
-        mod.add_shared()
+    if register_shared is True:
+        mod.register_shared()
 
     return glue, mod
 

--- a/gluetool/tests/test_shared.py
+++ b/gluetool/tests/test_shared.py
@@ -1,11 +1,11 @@
 # pylint: disable=blacklisted-name
 
-import pytest
+import logging
 
+import pytest
 from mock import MagicMock
 
 import gluetool
-
 from . import NonLoadingGlue, create_module
 
 
@@ -17,6 +17,7 @@ class DummyModule(gluetool.Module):
 
     name = 'Dummy module'
 
+    @gluetool.shared_function
     def foo(self):
         pass
 
@@ -31,94 +32,211 @@ def fixture_module():
     return create_module(DummyModule)[1]
 
 
-def test_core_add_shared(glue):
+# Shared functions discovery
+
+# children of all these classes should support shared functions discovery
+_FIND_SHARED_FUNCTIONS_PARAMS = [
+    (
+        gluetool.Module,
+        (fixture_glue(), 'dummy'),
+        None
+    ),
+    (
+        gluetool.Glue,
+        tuple(),
+        {
+            'eval_context': '_eval_context'
+        }
+    )
+]
+
+@pytest.mark.parametrize('parent, init_args, additional_shared_functions', _FIND_SHARED_FUNCTIONS_PARAMS)
+def test_shared_functions(parent, init_args, additional_shared_functions, glue):
+    class Container(parent):
+        shared_functions = ('old_style',)
+
+        def old_style(self):
+            pass
+
+        @gluetool.shared_function
+        def foo(self):
+            pass
+
+        @gluetool.shared_function(name='baz')
+        def bar(self):
+            pass
+
+    container = Container(*init_args)
+
+    expected_shared_functions = {
+        'foo': container.foo,
+        'baz': container.bar,
+        'old_style': container.old_style
+    }
+
+    if additional_shared_functions:
+        expected_shared_functions.update({
+            name: getattr(container, member) for name, member in additional_shared_functions.iteritems()
+        })
+
+    assert container._shared_functions() == expected_shared_functions
+
+    assert container.foo._gluetool_shared_function is True
+    assert container.foo._gluetool_shared_name == 'foo'
+    assert container.bar._gluetool_shared_function is True
+    assert container.bar._gluetool_shared_name == 'baz'
+
+
+@pytest.mark.parametrize('parent, init_args, additional_shared_functions', _FIND_SHARED_FUNCTIONS_PARAMS)
+def test_shared_functions_missing(parent, init_args, additional_shared_functions, glue):
+    class Container(parent):
+        shared_functions = ('foo',)
+
+        def bar(self):
+            pass
+
+    # Glue raises the exception when being instantiated, while Module when _shared_functions is called.
+    # Therefore the ``if`` - we cannot use ``container = Container()`` and use ``container.unique_name`` in
+    # the ``match``, because with ``parent`` being ``Glue``, we cannot instantiate container without
+    # detecting missing shared function.
+
+    if parent is gluetool.Glue:
+        with pytest.raises(gluetool.GlueError, match=r"No such shared function 'foo' of module 'gluetool core'"):
+            Container(*init_args)._shared_functions()
+
+    else:
+        with pytest.raises(gluetool.GlueError, match=r"No such shared function 'foo' of module 'dummy'"):
+            Container(*init_args)._shared_functions()
+
+
+def test_glue_register_shared(glue):
     module = MagicMock()
     func = MagicMock()
 
+    glue.register_shared('dummy_func', module, func)
+
     # pylint: disable=protected-access
-    glue._add_shared('dummy_func', module, func)
-
-    assert glue.shared_functions['dummy_func'] == (module, func)
+    assert glue._shared_functions_registry['dummy_func'] == (module, func)
 
 
-def test_add_shared(glue, monkeypatch):
-    dummy_func = MagicMock()
-    module = MagicMock(dummy_func=dummy_func)
+def test_register_shared(glue, monkeypatch):
+    class Module(gluetool.Module):
+        @gluetool.shared_function
+        def foo(self):
+            pass
 
-    _add_shared = MagicMock()
+    monkeypatch.setattr(glue, 'register_shared', MagicMock())
 
-    monkeypatch.setattr(glue, '_add_shared', _add_shared)
+    module = Module(glue, 'dummy')
+    module.register_shared()
 
-    glue.add_shared('dummy_func', module)
-
-    _add_shared.assert_called_once_with('dummy_func', module, dummy_func)
-
-
-def test_add_shared_missing(glue):
-    module = MagicMock(spec=gluetool.Module)
-    module.name = 'dummy_module'
-
-    with pytest.raises(gluetool.GlueError, match=r"No such shared function 'dummy_func' of module 'dummy_module'"):
-        glue.add_shared('dummy_func', module)
+    glue.register_shared.assert_called_once_with('foo', module, module.foo)
 
 
-def test_del_shared(glue):
-    glue.shared_functions['foo'] = None
+def test_glue_unregister_shared(glue):
+    glue._shared_functions_registry['foo'] = None
+    assert 'foo' in glue._shared_functions_registry
 
-    glue.del_shared('foo')
+    glue.unregister_shared('foo')
+
+    assert 'foo' not in glue._shared_functions_registry
 
 
-def test_del_shared_unknown(glue):
-    glue.del_shared('foo')
+def test_unregister_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'unregister_shared', MagicMock())
+
+    assert 'foo' in module.glue._shared_functions_registry
+
+    module.unregister_shared()
+
+    module.glue.unregister_shared.assert_called_once_with('foo')
 
 
-def test_has_shared(glue):
-    glue.shared_functions['foo'] = None
+def test_glue_unregister_shared_unknown(glue):
+    assert 'foo' not in glue._shared_functions_registry
+
+    glue.unregister_shared('foo')
+
+
+def test_glue_has_shared(glue):
+    glue._shared_functions_registry['foo'] = None
+    assert 'foo' in glue._shared_functions_registry
 
     assert glue.has_shared('foo') is True
 
 
+def test_has_shared(module, monkeypatch):
+    mock_return_value = MagicMock()
+    monkeypatch.setattr(module.glue, 'has_shared', MagicMock(return_value=mock_return_value))
+
+    assert module.has_shared('foo') == mock_return_value
+    module.glue.has_shared.assert_called_once_with('foo')
+
+
 def test_has_shared_unknown(glue):
+    assert 'foo' not in glue._shared_functions_registry
     assert glue.has_shared('foo') is False
 
 
-def test_shared(glue):
-    glue.shared_functions['foo'] = (None, MagicMock(return_value=17))
+def test_glue_shared(glue):
+    glue._shared_functions_registry['foo'] = (None, MagicMock(return_value=17))
 
     assert glue.shared('foo', 13, 11, 'bar', arg='baz') == 17
-    glue.shared_functions['foo'][1].assert_called_once_with(13, 11, 'bar', arg='baz')
+    glue._shared_functions_registry['foo'][1].assert_called_once_with(13, 11, 'bar', arg='baz')
 
 
-def test_shared_unknown(glue):
-    assert glue.shared('foo', 13, 11, 'bar', arg='baz') is None
-
-
-def test_module_shared(module, monkeypatch):
+def test_shared(module, monkeypatch):
     monkeypatch.setattr(module.glue, 'shared', MagicMock(return_value=17))
 
     assert module.shared('foo', 11, 13, 'bar', arg='baz') == 17
     module.glue.shared.assert_called_once_with('foo', 11, 13, 'bar', arg='baz')
 
 
-def test_module_add_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'add_shared', MagicMock())
-    module.shared_functions = ('foo',)
-
-    module.add_shared()
-
-    module.glue.add_shared.assert_called_once_with('foo', module)
+def test_glue_shared_unknown(glue):
+    assert glue.shared('foo', 13, 11, 'bar', arg='baz') is None
 
 
-def test_module_del_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'del_shared', MagicMock())
+def test_glue_get_shared(glue):
+    glue._shared_functions_registry['foo'] = (None, MagicMock())
 
-    module.del_shared('foo')
-
-    module.glue.del_shared.assert_called_once_with('foo')
+    assert glue.get_shared('foo') == glue._shared_functions_registry['foo'][1]
 
 
-def test_module_has_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'has_shared', MagicMock(return_value=17))
+def test_glue_get_shared_unknown(glue):
+    assert glue.get_shared('foo') is None
 
-    assert module.has_shared('foo') == 17
-    module.glue.has_shared.assert_called_once_with('foo')
+
+def test_get_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'get_shared', MagicMock())
+
+    module.get_shared('foo')
+
+    module.glue.get_shared.assert_called_once_with('foo')
+
+
+def test_glue_require_shared(glue):
+    glue._shared_functions_registry.update({
+        'foo': None,
+        'bar': None
+    })
+
+    glue.require_shared('foo', 'bar')
+
+
+def test_glue_require_shared_missing(glue):
+    with pytest.raises(gluetool.GlueError, match=r"Shared function 'foo' is required. See `gluetool -L` to find out which module provides it."):
+        glue.require_shared('foo', 'bar')
+
+
+def test_glue_require_shared_missing_warning(glue, log):
+    glue.require_shared('foo', 'bar', warn_only=True)
+
+    log.match(message="Shared function 'foo' is required. See `gluetool -L` to find out which module provides it.", levelno=logging.WARN)
+
+
+def test_require_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'require_shared', MagicMock())
+
+    module.require_shared('foo', 'bar', warn_only=True)
+
+    module.glue.require_shared.assert_called_once_with('foo', 'bar', warn_only=True)


### PR DESCRIPTION
Instead of listing shared functions, simply use the decorator.