### PR TITLE
Revert "@shared_function decorator (#23)"

### DIFF
--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -88,7 +88,7 @@ Below is an example of configuration for this ``openstack`` module.
 Shared Functions
 ^^^^^^^^^^^^^^^^
 
-Shared functions are the only way how modules can share data to the subsequent modules on the command-line pipeline. Each module can expose its shared functions by by decorating its methods by :py:attr:`shared_functions <gluetool.shared_function>` decorator. The available shared functions then can be easily called from any subsequent module being executed via the :py:meth:`shared <gluetool.glue.Module.shared>` method.
+Shared functions are the only way how modules can share data to the subsequent modules on the command-line pipeline. Each module can define a shared function via the :py:attr:`shared_functions <gluetool.glue.Module.shared_functions>` list. The available shared functions then can be easily called from any subsequent module being executed via the :py:meth:`shared <gluetool.glue.Module.shared>` method.
 
 To list all shared functions provided by the available modules, use the gluetool's `-L` option
 

--- a/docs/source/howto-modules.rst
+++ b/docs/source/howto-modules.rst
@@ -64,7 +64,7 @@ Shared functions
 
 See the :ref:`framework's documentation <shared-functions>` for introduction into shared functions.
 
-A module can define any number of shared functions by decorating its methods with :py:func:`gluetool.shared_function` decorator. The shared functions are made available to other modules after the module has been executed. This makes it possible for the module to redefine the previously defined shared functions with their own version.
+A module can define any number of shared functions by listing their name as a string in the :py:attr:`gluetool.glue.Module.shared_functions <shared_functions>` list. The shared functions are made available to other modules after the module has been executed. This makes it possible for the module to redefine the previously defined shared functions with their own version.
 
 Here is an example of a simple module that exposes myapi shared function and takes one optional argument specifying the api version.
 
@@ -75,7 +75,8 @@ Here is an example of a simple module that exposes myapi shared function and tak
     class MyApiModule(gluetool.Module):
         name = 'myapi'
 
-        @gluetool.shared_function
+        shared_functions = ['myapi']
+
         def myapi(self, api_version=1):
             return 'My Api version: {}'.format(api_version)
 
@@ -107,8 +108,8 @@ For example, imagine two "publishing" modules - one sends messages to "alpha", t
 
     class PublishAlpha(gluetool.Module):
         name = 'publish-alpha'
+        shared_functions = ['publish']
 
-        @gluetool.shared_function
         def publish(self, message):
             self.info("publishing to alpha '{}'".format(message))
             self.overloaded_shared('publish', message)
@@ -119,8 +120,8 @@ For example, imagine two "publishing" modules - one sends messages to "alpha", t
 
     class PublishOmega(gluetool.Module):
         name = 'publish-omega'
+        shared_functions = ['publish']
 
-        @gluetool.shared_function
         def publish(self, message):
             self.info("publishing to omega '{}'".format(message))
             self.overloaded_shared('publish', message)

--- a/gluetool/__init__.py
+++ b/gluetool/__init__.py
@@ -1,7 +1,7 @@
-from .glue import Glue, Module, shared_function
+from .glue import Glue, Module
 from .glue import GlueError, SoftGlueError, GlueRetryError, GlueCommandError, Failure
 from . import utils
 
-__all__ = ['Glue', 'Module', 'shared_function',
+__all__ = ['Glue', 'Module',
            'GlueError', 'SoftGlueError', 'GlueRetryError', 'GlueCommandError', 'Failure',
            'utils']

--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -3,7 +3,6 @@
 import argparse
 import ConfigParser
 import imp
-import inspect
 import logging
 import os
 import sys
@@ -203,36 +202,6 @@ def retry(*args):
     return wrap
 
 
-def shared_function(*args, **kwargs):
-    """
-    Use to mark module method as shared.
-
-    :param str name: If set, it is used as a shared function name instead of ``__name__`` of decorated function.
-    """
-
-    name = kwargs.pop('name', None)
-
-    def shared_function_decorator(func):
-        # pylint: disable=protected-access
-
-        # mark original function to be shared, to tell it apart from other methods
-        func._gluetool_shared_function = True
-
-        # record desired name - may be different from __name__
-        func._gluetool_shared_name = name or func.__name__
-
-        return func
-
-    # If the outer function gets an argument, it's been called without parameters (@shared_function).
-    # in that case, apply decorator.
-    if args:
-        return shared_function_decorator(args[0])
-
-    # Without any argument, kwargs were provided (@shared_function(name=...)), and in that case
-    # we return the decorator itself - Python will apply later to the decorated function.
-    return shared_function_decorator
-
-
 class PipelineStep(object):
     # pylint: disable=too-few-public-methods
     """
@@ -343,13 +312,6 @@ class Configurable(object):
     """
     Unque name of this instance. Used by modules, has no meaning elsewhere, but since dry-run
     checks are done on this level, it must be declared here to make pylint happy :/
-    """
-
-    shared_functions = ()
-    """
-    Iterable of shared function names provided by the module.
-
-    This is a legacy method of specifying shared functions, use ``@gluetool.shared`` decorator instead.
     """
 
     @staticmethod
@@ -714,41 +676,6 @@ class Configurable(object):
 
         return {}
 
-    # This method cannot be a property, because it uses ``inspect.getmembers(self)`` to find all
-    # members of ``self``, and pick those decorated with ``shared_function`` decorator. ``getmembers``
-    # will return list of pairs (name, member), and one of those mebers would be ``_shared_functions``
-    # property, and ``getmembers`` would trigger property's getter, which would be this method, calling
-    # ``getmembers`` again, depleting the stack in an endless recursion.
-    # On the other hand, ``member`` in the case of a mere method is just the method, not its return
-    # value, so method is safe.
-    def _shared_functions(self):
-        """
-        Return all shared functions exported by this instance.
-
-        :rtype: dict(name, callable)
-        """
-
-        functions = {}
-
-        # First, find all shared functions specified using "legacy" method, listing them in self.shared_functions
-
-        # This could be written as a dictionary comprehension but in the case of an attribute error, we'd have
-        # to parse function name from exception's args.
-        for name in self.shared_functions:
-            if not hasattr(self, name):
-                raise GlueError("No such shared function '{}' of module '{}'".format(name, self.unique_name))
-
-            functions[name] = getattr(self, name)
-
-        # Second, check all methods of self, and find those decorated by @shared_function
-        # pylint: disable=protected-access
-        functions.update({
-            method._gluetool_shared_name: method for name, method in inspect.getmembers(self, inspect.ismethod)
-            if getattr(method, '_gluetool_shared_function', False)
-        })
-
-        return functions
-
 
 class Module(Configurable):
     """
@@ -772,6 +699,9 @@ class Module(Configurable):
 
     description = None
     """Short module description, displayed in ``gluetool``'s module listing."""
+
+    shared_functions = []
+    """Iterable of names of shared functions exported by the module."""
 
     def _paths_with_module(self, roots):
         """
@@ -824,16 +754,18 @@ class Module(Configurable):
         :returns: Formatted help, describing module's shared functions.
         """
 
-        shared_functions = self._shared_functions()
-
-        if not shared_functions:
+        if not self.shared_functions:
             return ''
 
         from .help import functions_help
 
-        functions = [
-            (name, func) for name, func in shared_functions.iteritems()
-        ]
+        functions = []
+
+        for name in self.shared_functions:
+            if not hasattr(self, name):
+                raise GlueError("No such shared function '{}' of module '{}'".format(name, self.unique_name))
+
+            functions.append((name, getattr(self, name)))
 
         return jinja2.Template(trim_docstring("""
         {{ '** Shared functions **' | style(fg='yellow') }}
@@ -866,24 +798,20 @@ class Module(Configurable):
 
         return None
 
-    def register_shared(self):
+    def add_shared(self):
         """
-        Register all module's shared functions with Glue, making them available to other modules.
+        Register module's shared functions with Glue, to allow other modules
+        to use them.
         """
 
-        for funcname, func in self._shared_functions().iteritems():
+        for funcname in self.shared_functions:
             if self.has_shared(funcname):
                 self._overloaded_shared_functions[funcname] = self.get_shared(funcname)
 
-            self.glue.register_shared(funcname, self, func)
+            self.glue.add_shared(funcname, self)
 
-    def unregister_shared(self):
-        """
-        Unregister all shared functions of the module, making them unavailable to other modules.
-        """
-
-        for funcname in self._shared_functions().iterkeys():
-            self.glue.unregister_shared(funcname)
+    def del_shared(self, funcname):
+        self.glue.del_shared(funcname)
 
     def has_shared(self, funcname):
         return self.glue.has_shared(funcname)
@@ -950,7 +878,6 @@ class Glue(Configurable):
     """
 
     name = 'gluetool core'
-    unique_name = 'gluetool core'
 
     options = [
         ('Global options', {
@@ -1098,34 +1025,45 @@ class Glue(Configurable):
         See :py:meth:`gluetool.sentry.Sentry.submit_warning`.
         """
 
-    def register_shared(self, funcname, module, func):
+    def _add_shared(self, funcname, module, func):
+        """
+        Register a shared function. Overwrite previously registered function
+        with the same name, if there was any such.
+
+        This is a helper method for easier testability. It is not a part of public API of this class.
+
+        :param str funcname: Name of the shared function.
+        :param gluetool.glue.Module module: Module instance providing the shared function.
+        :param callable func: Shared function.
+        """
+
+        self.debug("registering shared function '{}' of module '{}'".format(funcname, module.unique_name))
+
+        self.shared_functions[funcname] = (module, func)
+
+    def add_shared(self, funcname, module):
         """
         Register a shared function. Overwrite previously registered function
         with the same name, if there was any such.
 
         :param str funcname: Name of the shared function.
         :param gluetool.glue.Module module: Module instance providing the shared function.
-        :param callable func: The actual shared function.
         """
 
-        self.debug("registering shared function '{}' of module '{}'".format(funcname, module.unique_name))
+        if not hasattr(module, funcname):
+            raise GlueError("No such shared function '{}' of module '{}'".format(funcname, module.name))
 
-        self._shared_functions_registry[funcname] = (module, func)
+        self._add_shared(funcname, module, getattr(module, funcname))
 
-    def unregister_shared(self, funcname):
-        """
-        Unregister a shared function.
-
-        :param str funcname: Name of the shared function.
-        """
-
-        if funcname not in self._shared_functions_registry:
+    # delete a shared function if exists
+    def del_shared(self, funcname):
+        if funcname not in self.shared_functions:
             return
 
-        del self._shared_functions_registry[funcname]
+        del self.shared_functions[funcname]
 
     def has_shared(self, funcname):
-        return funcname in self._shared_functions_registry
+        return funcname in self.shared_functions
 
     def require_shared(self, *names, **kwargs):
         warn_only = kwargs.get('warn_only', False)
@@ -1149,13 +1087,13 @@ class Glue(Configurable):
         if not self.has_shared(funcname):
             return None
 
-        return self._shared_functions_registry[funcname][1]
+        return self.shared_functions[funcname][1]
 
     def shared(self, funcname, *args, **kwargs):
-        if funcname not in self._shared_functions_registry:
+        if funcname not in self.shared_functions:
             return None
 
-        return self._shared_functions_registry[funcname][1](*args, **kwargs)
+        return self.shared_functions[funcname][1](*args, **kwargs)
 
     @property
     def eval_context(self):
@@ -1172,7 +1110,6 @@ class Glue(Configurable):
             'ENV': dict(os.environ)
         }
 
-    @shared_function(name='eval_context')
     def _eval_context(self):
         """
         Gather contexts of all modules in a pipeline and merge them together.
@@ -1432,11 +1369,9 @@ class Glue(Configurable):
 
         #: Shared function registry.
         #: funcname: (module, fn)
-        self._shared_functions_registry = {}
+        self.shared_functions = {}
 
-        # register global shared functions
-        for funcname, func in self._shared_functions().iteritems():
-            self.register_shared(funcname, self, func)
+        self._add_shared('eval_context', self, self._eval_context)
 
     # pylint: disable=arguments-differ
     def parse_config(self, paths):
@@ -1580,7 +1515,7 @@ class Glue(Configurable):
 
         def _execute(module):
             module.execute()
-            module.register_shared()
+            module.add_shared()
 
         self._for_each_module(modules, _execute)
 

--- a/gluetool/tests/__init__.py
+++ b/gluetool/tests/__init__.py
@@ -75,12 +75,12 @@ class CaplogWrapper(object):
         return matcher(_cmp(record) for record in self.records)
 
 
-def create_module(module_class, glue=None, glue_class=NonLoadingGlue, name='dummy-module', register_shared=True):
+def create_module(module_class, glue=None, glue_class=NonLoadingGlue, name='dummy-module', add_shared=True):
     glue = glue or glue_class()
     mod = module_class(glue, name)
 
-    if register_shared is True:
-        mod.register_shared()
+    if add_shared is True:
+        mod.add_shared()
 
     return glue, mod
 

--- a/gluetool/tests/test_shared.py
+++ b/gluetool/tests/test_shared.py
@@ -1,11 +1,11 @@
 # pylint: disable=blacklisted-name
 
-import logging
-
 import pytest
+
 from mock import MagicMock
 
 import gluetool
+
 from . import NonLoadingGlue, create_module
 
 
@@ -17,7 +17,6 @@ class DummyModule(gluetool.Module):
 
     name = 'Dummy module'
 
-    @gluetool.shared_function
     def foo(self):
         pass
 
@@ -32,211 +31,94 @@ def fixture_module():
     return create_module(DummyModule)[1]
 
 
-# Shared functions discovery
-
-# children of all these classes should support shared functions discovery
-_FIND_SHARED_FUNCTIONS_PARAMS = [
-    (
-        gluetool.Module,
-        (fixture_glue(), 'dummy'),
-        None
-    ),
-    (
-        gluetool.Glue,
-        tuple(),
-        {
-            'eval_context': '_eval_context'
-        }
-    )
-]
-
-@pytest.mark.parametrize('parent, init_args, additional_shared_functions', _FIND_SHARED_FUNCTIONS_PARAMS)
-def test_shared_functions(parent, init_args, additional_shared_functions, glue):
-    class Container(parent):
-        shared_functions = ('old_style',)
-
-        def old_style(self):
-            pass
-
-        @gluetool.shared_function
-        def foo(self):
-            pass
-
-        @gluetool.shared_function(name='baz')
-        def bar(self):
-            pass
-
-    container = Container(*init_args)
-
-    expected_shared_functions = {
-        'foo': container.foo,
-        'baz': container.bar,
-        'old_style': container.old_style
-    }
-
-    if additional_shared_functions:
-        expected_shared_functions.update({
-            name: getattr(container, member) for name, member in additional_shared_functions.iteritems()
-        })
-
-    assert container._shared_functions() == expected_shared_functions
-
-    assert container.foo._gluetool_shared_function is True
-    assert container.foo._gluetool_shared_name == 'foo'
-    assert container.bar._gluetool_shared_function is True
-    assert container.bar._gluetool_shared_name == 'baz'
-
-
-@pytest.mark.parametrize('parent, init_args, additional_shared_functions', _FIND_SHARED_FUNCTIONS_PARAMS)
-def test_shared_functions_missing(parent, init_args, additional_shared_functions, glue):
-    class Container(parent):
-        shared_functions = ('foo',)
-
-        def bar(self):
-            pass
-
-    # Glue raises the exception when being instantiated, while Module when _shared_functions is called.
-    # Therefore the ``if`` - we cannot use ``container = Container()`` and use ``container.unique_name`` in
-    # the ``match``, because with ``parent`` being ``Glue``, we cannot instantiate container without
-    # detecting missing shared function.
-
-    if parent is gluetool.Glue:
-        with pytest.raises(gluetool.GlueError, match=r"No such shared function 'foo' of module 'gluetool core'"):
-            Container(*init_args)._shared_functions()
-
-    else:
-        with pytest.raises(gluetool.GlueError, match=r"No such shared function 'foo' of module 'dummy'"):
-            Container(*init_args)._shared_functions()
-
-
-def test_glue_register_shared(glue):
+def test_core_add_shared(glue):
     module = MagicMock()
     func = MagicMock()
 
-    glue.register_shared('dummy_func', module, func)
-
     # pylint: disable=protected-access
-    assert glue._shared_functions_registry['dummy_func'] == (module, func)
+    glue._add_shared('dummy_func', module, func)
+
+    assert glue.shared_functions['dummy_func'] == (module, func)
 
 
-def test_register_shared(glue, monkeypatch):
-    class Module(gluetool.Module):
-        @gluetool.shared_function
-        def foo(self):
-            pass
+def test_add_shared(glue, monkeypatch):
+    dummy_func = MagicMock()
+    module = MagicMock(dummy_func=dummy_func)
 
-    monkeypatch.setattr(glue, 'register_shared', MagicMock())
+    _add_shared = MagicMock()
 
-    module = Module(glue, 'dummy')
-    module.register_shared()
+    monkeypatch.setattr(glue, '_add_shared', _add_shared)
 
-    glue.register_shared.assert_called_once_with('foo', module, module.foo)
+    glue.add_shared('dummy_func', module)
 
-
-def test_glue_unregister_shared(glue):
-    glue._shared_functions_registry['foo'] = None
-    assert 'foo' in glue._shared_functions_registry
-
-    glue.unregister_shared('foo')
-
-    assert 'foo' not in glue._shared_functions_registry
+    _add_shared.assert_called_once_with('dummy_func', module, dummy_func)
 
 
-def test_unregister_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'unregister_shared', MagicMock())
+def test_add_shared_missing(glue):
+    module = MagicMock(spec=gluetool.Module)
+    module.name = 'dummy_module'
 
-    assert 'foo' in module.glue._shared_functions_registry
-
-    module.unregister_shared()
-
-    module.glue.unregister_shared.assert_called_once_with('foo')
+    with pytest.raises(gluetool.GlueError, match=r"No such shared function 'dummy_func' of module 'dummy_module'"):
+        glue.add_shared('dummy_func', module)
 
 
-def test_glue_unregister_shared_unknown(glue):
-    assert 'foo' not in glue._shared_functions_registry
+def test_del_shared(glue):
+    glue.shared_functions['foo'] = None
 
-    glue.unregister_shared('foo')
+    glue.del_shared('foo')
 
 
-def test_glue_has_shared(glue):
-    glue._shared_functions_registry['foo'] = None
-    assert 'foo' in glue._shared_functions_registry
+def test_del_shared_unknown(glue):
+    glue.del_shared('foo')
+
+
+def test_has_shared(glue):
+    glue.shared_functions['foo'] = None
 
     assert glue.has_shared('foo') is True
 
 
-def test_has_shared(module, monkeypatch):
-    mock_return_value = MagicMock()
-    monkeypatch.setattr(module.glue, 'has_shared', MagicMock(return_value=mock_return_value))
-
-    assert module.has_shared('foo') == mock_return_value
-    module.glue.has_shared.assert_called_once_with('foo')
-
-
 def test_has_shared_unknown(glue):
-    assert 'foo' not in glue._shared_functions_registry
     assert glue.has_shared('foo') is False
 
 
-def test_glue_shared(glue):
-    glue._shared_functions_registry['foo'] = (None, MagicMock(return_value=17))
+def test_shared(glue):
+    glue.shared_functions['foo'] = (None, MagicMock(return_value=17))
 
     assert glue.shared('foo', 13, 11, 'bar', arg='baz') == 17
-    glue._shared_functions_registry['foo'][1].assert_called_once_with(13, 11, 'bar', arg='baz')
+    glue.shared_functions['foo'][1].assert_called_once_with(13, 11, 'bar', arg='baz')
 
 
-def test_shared(module, monkeypatch):
+def test_shared_unknown(glue):
+    assert glue.shared('foo', 13, 11, 'bar', arg='baz') is None
+
+
+def test_module_shared(module, monkeypatch):
     monkeypatch.setattr(module.glue, 'shared', MagicMock(return_value=17))
 
     assert module.shared('foo', 11, 13, 'bar', arg='baz') == 17
     module.glue.shared.assert_called_once_with('foo', 11, 13, 'bar', arg='baz')
 
 
-def test_glue_shared_unknown(glue):
-    assert glue.shared('foo', 13, 11, 'bar', arg='baz') is None
+def test_module_add_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'add_shared', MagicMock())
+    module.shared_functions = ('foo',)
+
+    module.add_shared()
+
+    module.glue.add_shared.assert_called_once_with('foo', module)
 
 
-def test_glue_get_shared(glue):
-    glue._shared_functions_registry['foo'] = (None, MagicMock())
+def test_module_del_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'del_shared', MagicMock())
 
-    assert glue.get_shared('foo') == glue._shared_functions_registry['foo'][1]
+    module.del_shared('foo')
 
-
-def test_glue_get_shared_unknown(glue):
-    assert glue.get_shared('foo') is None
+    module.glue.del_shared.assert_called_once_with('foo')
 
 
-def test_get_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'get_shared', MagicMock())
+def test_module_has_shared(module, monkeypatch):
+    monkeypatch.setattr(module.glue, 'has_shared', MagicMock(return_value=17))
 
-    module.get_shared('foo')
-
-    module.glue.get_shared.assert_called_once_with('foo')
-
-
-def test_glue_require_shared(glue):
-    glue._shared_functions_registry.update({
-        'foo': None,
-        'bar': None
-    })
-
-    glue.require_shared('foo', 'bar')
-
-
-def test_glue_require_shared_missing(glue):
-    with pytest.raises(gluetool.GlueError, match=r"Shared function 'foo' is required. See `gluetool -L` to find out which module provides it."):
-        glue.require_shared('foo', 'bar')
-
-
-def test_glue_require_shared_missing_warning(glue, log):
-    glue.require_shared('foo', 'bar', warn_only=True)
-
-    log.match(message="Shared function 'foo' is required. See `gluetool -L` to find out which module provides it.", levelno=logging.WARN)
-
-
-def test_require_shared(module, monkeypatch):
-    monkeypatch.setattr(module.glue, 'require_shared', MagicMock())
-
-    module.require_shared('foo', 'bar', warn_only=True)
-
-    module.glue.require_shared.assert_called_once_with('foo', 'bar', warn_only=True)
+    assert module.has_shared('foo') == 17
+    module.glue.has_shared.assert_called_once_with('foo')


### PR DESCRIPTION
This reverts commit 62aa9948781cdf14c22e36439167288924bdd633.

This feature caused issues with properties - when discovering shared
functions, properties - and cached properties as well! - got evauluated,
leading to unexpected side effects. Needs more complex fix.