### PR TITLE
Deprecate fetch_url, use requests instead

### DIFF
--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -629,7 +629,7 @@ class Logging(object):
 
     OUR_LOGGERS = (
         logging.getLogger('gluetool'),
-        logging.getLogger("urllib3")
+        logging.getLogger('urllib3')
     )
 
     @staticmethod

--- a/gluetool/tests/test_requests.py
+++ b/gluetool/tests/test_requests.py
@@ -1,0 +1,24 @@
+import functools
+import requests as original_requests
+
+import pytest
+
+from gluetool.utils import requests
+
+
+def test_sanity():
+    method_names = ('head', 'get', 'post', 'put', 'patch', 'delete')
+
+    original_methods = {
+        method_name: getattr(original_requests, method_name) for method_name in method_names
+    }
+
+    with requests() as R:
+        assert R == original_requests
+
+        for method_name in method_names:
+            original_method = original_methods[method_name]
+            actual_method = getattr(R, method_name)
+
+            assert isinstance(actual_method, functools.partial)
+            assert actual_method.args[0] == original_method

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ if __name__ == '__main__':
               'lxml==3.7.3',
               'packaging==16.8',
               'raven==6.0.0',
+              'requests==2.18.4',
+              'requests-toolbelt==0.8.0',
               'ruamel.yaml==0.15.34',
               'Sphinx==1.5.2',
               'sphinx-rtd-theme==0.1.9',


### PR DESCRIPTION
The vast majority of the patch is just extending logging subsystem to
cover known ways requests logs its actions - its logger, httplib
internal logging - and how to plug both sides together.