### PR TITLE
Let user ask option() for multiple options

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -563,19 +563,23 @@ class Configurable(object):
             if name not in self._config or not self._config[name]:
                 raise GlueError("Missing required '{}' option".format(name))
 
-    def option(self, name):
+    def option(self, *names):
         """
-        Return a value of given option from module's configuration store.
+        Return values of given options from module's configuration store.
 
-        :param str name: name of requested option.
-        :returns: option value or ``None`` when no such option exists.
+        :param str names: names of requested options.
+        :returns: either a value or ``None`` if such option does not exist. When multiple options are requested,
+            a tuple of their values is returned, for a single option its value is **not** wrapped by a tuple.
         """
 
-        try:
-            return self._config[name]
+        if not names:
+            raise GlueError('Specify at least one option')
 
-        except KeyError:
-            return None
+        values = tuple(
+            self._config.get(name, None) for name in names
+        )
+
+        return values[0] if len(values) == 1 else values
 
     @property
     def dryrun_level(self):

--- a/gluetool/tests/test_option.py
+++ b/gluetool/tests/test_option.py
@@ -1,0 +1,58 @@
+# pylint: disable=blacklisted-name
+
+import pytest
+
+from mock import MagicMock
+
+import gluetool
+
+from . import create_module
+
+
+class DummyModule(gluetool.Module):
+    """
+    Dummy module, implementing necessary methods and attributes
+    to pass through Glue's internal machinery.
+    """
+
+    name = 'Dummy module'
+
+    options = {
+        'foo': {},
+        'bar': {}
+    }
+
+
+@pytest.fixture(name='module')
+def fixture_module():
+    return create_module(DummyModule)[1]
+
+
+@pytest.fixture(name='configured_module')
+def fixture_configured_module(module):
+    module._config.update({
+        'foo': 'some foo value',
+        'bar': 19
+    })
+
+    return module
+
+
+def test_sanity(module):
+    assert module.option('foo') is None
+
+
+def test_existing_option(configured_module):
+    assert configured_module.option('foo') == 'some foo value'
+
+
+def test_multiple_options(configured_module):
+    foo, bar = configured_module.option('foo', 'bar')
+
+    assert foo == 'some foo value'
+    assert bar == 19
+
+
+def test_no_option(module):
+    with pytest.raises(gluetool.GlueError, match=r'Specify at least one option'):
+        module.option()


### PR DESCRIPTION
When asking for just one, return its value directly (current behavior),
when asking for multiple, return all their values, and let user unpack
them from returned tuple into their own variables. E.g.

  foo = self.option('foo')
  bar, baz = self.option('bar', 'baz')