### PR TITLE
Add 'MODULE' variable to each eval context

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -1119,7 +1119,7 @@ class Glue(Configurable):
         """
         Infere module instance calling the eval context shared function.
 
-        :rtype: gluetool.glue..Module
+        :rtype: gluetool.glue.Module
         """
 
         stack = inspect.stack()

--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -3,6 +3,7 @@
 import argparse
 import ConfigParser
 import imp
+import inspect
 import logging
 import os
 import sys
@@ -1114,6 +1115,36 @@ class Glue(Configurable):
             'ENV': dict(os.environ)
         }
 
+    def _eval_context_module_caller(self):
+        """
+        Infere module instance calling the eval context shared function.
+
+        :rtype: gluetool.glue..Module
+        """
+
+        stack = inspect.stack()
+        log_dict(self.verbose, 'stack', stack)
+
+        # When being called as a regular shared function, the call stack layout should be
+        # as follows:
+        #
+        # Glue._eval_context_module_caller - this helper method, caller of inspect.stack()
+        # Glue._eval_context - our caller, the actual shared function body
+        # Glue.shared - shared function call dispatcher of Glue class, calls Glue._eval_context
+        # Module.shared - shared function call dispatcher of Module class, calls Glue.shared internally
+
+        # pylint: disable=too-many-boolean-expressions
+        if len(stack) < 4 \
+           or stack[0][3] != '_eval_context_module_caller' \
+           or stack[1][3] != '_eval_context' \
+           or stack[2][3] != 'shared' \
+           or stack[3][3] != 'shared' \
+           or 'self' not in stack[3][0].f_locals:
+            self.warn('Cannot infer calling module of eval_context')
+            return None
+
+        return stack[3][0].f_locals['self']
+
     def _eval_context(self):
         """
         Gather contexts of all modules in a pipeline and merge them together.
@@ -1129,7 +1160,9 @@ class Glue(Configurable):
 
         self.debug('gather pipeline eval context')
 
-        context = {}
+        context = {
+            'MODULE': self._eval_context_module_caller()
+        }
 
         # first "module" is this instance - it provides eval_context as well.
         for module in [self] + self._module_instances:

--- a/gluetool/tests/test_eval_context.py
+++ b/gluetool/tests/test_eval_context.py
@@ -1,0 +1,43 @@
+# pylint: disable=blacklisted-name
+
+import logging
+import pytest
+
+import gluetool
+
+from . import create_module
+
+
+class DummyModule(gluetool.Module):
+    """
+    Dummy module, implementing necessary methods and attributes
+    to pass through Glue's internal machinery.
+    """
+
+    name = 'Dummy module'
+
+
+@pytest.fixture(name='module')
+def fixture_module():
+    return create_module(DummyModule)[1]
+
+
+def test_sanity(module):
+    module.shared('eval_context')
+
+
+def test_module(module):
+    eval_context = module.shared('eval_context')
+
+    assert 'MODULE' in eval_context
+    assert eval_context['MODULE'] is module
+
+
+def test_module_via_glue(module, log):
+    eval_context = module.glue.shared('eval_context')
+
+    assert 'MODULE' in eval_context
+    assert eval_context['MODULE'] is None
+
+    assert log.records[-2].message == 'Cannot infer calling module of eval_context'
+    assert log.records[-2].levelno == logging.WARNING


### PR DESCRIPTION
References the module instance that called eval_context shared function.
proved useful, to allow access to more advanced function and gluetool's
methods.