### PR TITLE
Pylint checker for options' default values & help texts

### DIFF
--- a/gluetool/pylint/__init__.py
+++ b/gluetool/pylint/__init__.py
@@ -2,10 +2,114 @@
 Handy custom PyLint checkers.
 """
 
+import collections
+import imp
+
+import astroid
+import pylint.utils
+
+from .option_default import register_checkers as register_option_default
 from .shared_defined import register_checkers as register_shared_defined
 from .unknown_option import register_checkers as register_unknown_option
 
 
+#: Represents information checker has on an option.
+#:
+#: :param list nodes: List of AST nodes. Currently, we're passing just a single one, the whole ``options`` dictionary,
+#:     but the idea is to implement search for deeper nodes, more precisely locating each option.
+#: :param closest_node: node closest in the tree to the definition of the option.
+#: :param dict params: option parameters, as described by the module author (``argparse`` keywords).
+OptionInfo = collections.namedtuple('OptionInfo', ('nodes', 'closest_node', 'params'))
+
+
+class OptionsGatherer(object):
+    # pylint: disable=too-few-public-methods
+
+    """
+    Finds option definitions in the module.
+    """
+
+    def __init__(self):
+        self.options = {}
+
+    @classmethod
+    def walk(cls, node):
+        gatherer = cls()
+
+        walker = pylint.utils.PyLintASTWalker(None)
+        walker.add_checker(gatherer)
+        walker.walk(node)
+
+        return gatherer
+
+    def visit_assign(self, node):
+        # pylint: disable=no-self-use
+
+        # skip anything that's not 'options = ...' on the class level
+        if not isinstance(node.targets[0], astroid.AssignName):
+            return
+
+        if node.targets[0].name != 'options':
+            return
+
+        if not isinstance(node.parent, astroid.ClassDef):
+            return
+
+        # We're processing options two times:
+        #
+        # 1) to find out options' parameters, which may require references to default values, global names,
+        # other modules and so on, we need to use Python's `exec` - Python will resolve everything, including
+        # imports;
+        #
+        # 2) the option above does not preserve information about nodes corresponding to options, `exec` does
+        # not care about them. We need to process AST to find these nodes, but we don't need to dive into options'
+        # parameters since we already have them.
+        #
+        # Well, it's not that easy: way #2 is **not** implemented yet, because it has to deal with many different
+        # ways ``options`` "dict" can be specified (dict, list, tuple, calls to dict_update, etc.) Leaving that
+        # for the future since it'd would be nice to find specific node for each option, to allow more precise
+        # disabling the checks, and also logging would be more precise.
+
+        # pylint: disable=exec-used
+
+        # Create a dummy module object, a placeholder.
+        module = imp.new_module('dummy-module')
+
+        # Fill it with the module data by executing the module AST node withing the context
+        # of our placeholder's namespace.
+        exec node.root().as_string() in module.__dict__
+
+        # Now "evaluate" options structure inside this module, assign it to chosen name...
+        exec '__pylint_options = {}'.format(node.value.as_string()) in module.__dict__
+
+        # ... and now pull the evaluated, Python data structure, out of the module namespace.
+        executed_options = module.__dict__['__pylint_options']
+
+        # Here will be the second method
+        # ...
+
+        def _add_options(options):
+            for name, params in options.iteritems():
+                if isinstance(name, str):
+                    self.options[name] = OptionInfo([node], node, params)
+
+                elif isinstance(name, (list, tuple)):
+                    self.options[name[1]] = OptionInfo([node], node, params)
+
+        if isinstance(executed_options, (list, tuple)):
+            for _, group_options in executed_options:
+                _add_options(group_options)
+
+            return
+
+        if isinstance(executed_options, dict):
+            _add_options(executed_options)
+            return
+
+        raise Exception('Unknown options type {}'.format(type(executed_options)))
+
+
 def register(linter):
+    register_option_default(linter)
     register_shared_defined(linter)
     register_unknown_option(linter)

--- a/gluetool/pylint/option_default.py
+++ b/gluetool/pylint/option_default.py
@@ -1,0 +1,134 @@
+"""
+Checker for using unknown module options.
+
+Does not handle multiple gluetool modules within the same Python module well, all their
+options are stored under the same key (file name), which leads to false negatives. This
+will be fixed later.
+"""
+
+from pylint.checkers import BaseChecker, utils
+from pylint.interfaces import IAstroidChecker
+
+
+BASE_ID = 76
+
+
+def register_checkers(linter):
+    linter.register_checker(OptionDefaultChecker(linter))
+
+
+class OptionDefaultChecker(BaseChecker):
+    """
+    Checks whether option help string, when describing a default value, uses ``%(default)s`` variable, and whether
+    such option has a default value set explicitly.
+
+    Bad:
+
+    .. code-block:: python
+
+       options = {
+           'foo': {
+               'help': 'Sets something (default: 79).'
+           },
+           'bar': {
+               'help': 'Sets something else (default: 79).',
+               'default': 79
+           },
+           'baz': {
+               'help': 'Sets something completely different.',
+               'default': 79
+           }
+       }
+
+    OK:
+
+    .. code-block:: python
+
+       options = {
+           'foo': {
+               'help': 'Sets something (default: %(defaults)s).',
+               'default': 79
+           },
+           'bar': {
+               'help': 'Sets something else (default: %(default)s).',
+               'default': 79
+           },
+           'baz': {
+               'help': 'Sets something completely different (default %(default)s).',
+               'default': 79
+           }
+       }
+
+    The message ID is ``gluetool-option-default``.
+    """
+
+    __implements__ = (IAstroidChecker,)
+
+    name = 'gluetool-option-default-checker'
+    priority = -1
+
+    MESSAGE_ID_NO_DEFAULT = 'gluetool-option-has-no-default'
+    MESSAGE_ID_NO_DEFAULT_IN_HELP = 'gluetool-option-no-default-in-help'
+    MESSAGE_ID_HARD_DEFAULT = 'gluetool-option-hard-default'
+
+    msgs = {
+        'E%d31' % BASE_ID: (
+            'option \'%s\' documents its default value without specifying it',
+            MESSAGE_ID_NO_DEFAULT,
+            'option documents its default without specifying it'
+        ),
+        'E%d32' % BASE_ID: (
+            'option \'%s\' has default value but does not document it',
+            MESSAGE_ID_NO_DEFAULT_IN_HELP,
+            'option has default value but does not document it'
+        ),
+        'E%d33' % BASE_ID: (
+            'option \'%s\' refers to its default value by stating the value instead of using \'%%(default)s\'',
+            MESSAGE_ID_HARD_DEFAULT,
+            'option refers to its default value by stating the value instead of using \'%(default)s\''
+        )
+    }
+
+    @utils.check_messages(MESSAGE_ID_NO_DEFAULT, MESSAGE_ID_NO_DEFAULT_IN_HELP, MESSAGE_ID_HARD_DEFAULT)
+    def visit_module(self, node):
+        # pylint: disable=no-self-use
+
+        # One of the first nodes the checker hits is the Module. Before inspecting any calls
+        # to self.option, we must inspect it and find option definitions because there might
+        # calls to gluetool module's option() method - in helper classes of functions, for example
+        # - that call their "parent"'s (our gluetool module) option() method. Such calls use option
+        # names that are unknown at the time this checker inspects them because their definitions
+        # come later, when the gluetool module is defined.
+
+        from . import OptionsGatherer
+        gatherer = OptionsGatherer.walk(node)
+
+        for name, info in gatherer.options.iteritems():
+            nodes, closest_node, params = info
+
+            help_text = params.get('help', None)
+
+            if not help_text:
+                continue
+
+            for option_node in nodes:
+                if not self.linter.is_message_enabled(self.MESSAGE_ID_NO_DEFAULT, line=option_node.fromlineno):
+                    return
+
+                if not self.linter.is_message_enabled(self.MESSAGE_ID_NO_DEFAULT_IN_HELP, line=option_node.fromlineno):
+                    return
+
+                if not self.linter.is_message_enabled(self.MESSAGE_ID_HARD_DEFAULT, line=option_node.fromlineno):
+                    return
+
+            if 'default: ' in help_text:
+                if 'default' not in params:
+                    self.add_message(self.MESSAGE_ID_NO_DEFAULT, args=name, node=closest_node)
+                    continue
+
+                if 'default: %(default)s' not in help_text:
+                    self.add_message(self.MESSAGE_ID_HARD_DEFAULT, args=name, node=closest_node)
+                    continue
+
+            elif 'default' in params:
+                self.add_message(self.MESSAGE_ID_NO_DEFAULT_IN_HELP, args=name, node=closest_node)

--- a/gluetool/pylint/unknown_option.py
+++ b/gluetool/pylint/unknown_option.py
@@ -6,11 +6,8 @@ options are stored under the same key (file name), which leads to false negative
 will be fixed later.
 """
 
-import imp
-
 import astroid
 
-import pylint
 from pylint.checkers import BaseChecker, utils
 from pylint.interfaces import IAstroidChecker
 
@@ -24,67 +21,6 @@ def register_checkers(linter):
 
 # Stores option names found in inspected files.
 OPTION_NAMES = {}
-
-
-class OptionsGatherer(object):
-    # pylint: disable=too-few-public-methods
-
-    """
-    Finds option definitions in the module.
-    """
-
-    def visit_assign(self, node):
-        # pylint: disable=no-self-use
-
-        # skip anything that's not 'options = ...' on the class level
-        if not isinstance(node.targets[0], astroid.AssignName):
-            return
-
-        if node.targets[0].name != 'options':
-            return
-
-        if not isinstance(node.parent, astroid.ClassDef):
-            return
-
-        # Options needs to be evaluated within the context of the module defining them - there
-        # may be imports, default values, global names, etc. therefore simple eval is not good enough.
-
-        # pylint: disable=exec-used
-
-        # Create a dummy module object, a placeholder.
-        module = imp.new_module('dummy-module')
-
-        # Fill it with the module data by executing the module AST node withing the context
-        # of our placeholder's namespace.
-        exec node.root().as_string() in module.__dict__
-
-        # Now "evaluate" options structure inside this module, assign it to chosen name...
-        exec '__pylint_options = {}'.format(node.value.as_string()) in module.__dict__
-
-        # ... and now pull the evaluated, Python data structure, out of the module namespace.
-        options = module.__dict__['__pylint_options']
-
-        option_names = OPTION_NAMES[node.root().file] = []
-
-        def _add_options(options):
-            for option_name in options.iterkeys():
-                if isinstance(option_name, str):
-                    option_names.append(option_name)
-
-                elif isinstance(option_name, (list, tuple)):
-                    option_names.append(option_name[1])
-
-        if isinstance(options, (list, tuple)):
-            for _, group_options in options:
-                _add_options(group_options)
-
-            return
-
-        if isinstance(options, dict):
-            _add_options(options)
-            return
-
-        raise Exception('Unknown options type {}'.format(type(options)))
 
 
 class OptionNameMatchChecker(BaseChecker):
@@ -130,15 +66,16 @@ class OptionNameMatchChecker(BaseChecker):
         # pylint: disable=no-self-use
 
         # One of the first nodes the checker hits is the Module. Before inspecting any calls
-        # to self.option, we must inspect it and find option definitions because there might
+        # to self.option, we must inspect it and find option definitions because there might be
         # calls to gluetool module's option() method - in helper classes of functions, for example
         # - that call their "parent"'s (our gluetool module) option() method. Such calls use option
         # names that are unknown at the time this checker inspects them because their definitions
         # come later, when the gluetool module is defined.
 
-        walker = pylint.utils.PyLintASTWalker(None)
-        walker.add_checker(OptionsGatherer())
-        walker.walk(node)
+        from . import OptionsGatherer
+        gatherer = OptionsGatherer.walk(node)
+
+        OPTION_NAMES[node.root().file] = gatherer.options.keys()
 
     @utils.check_messages(MESSAGE_ID)
     def visit_call(self, node):


### PR DESCRIPTION
New checker that makes sure that:

* when an option has a default value (`default` key in its parameters),
  it tells that to the user in its help text;
* when an option's help text does announce the default value, it uses
  `%(default)s` macro instead of hard-coding the value;
* when an option does not have a default value, it does not announce
  such a value in its help text.

See gluetool/pylint/option_default.py & OptionDefaultChecker for
examples, but TL;DR is simple - if an option has a default value, it
should say so in its help, and it should use a variable instead of
repeating the value.