### PR TITLE
setup.py: upgrade to Jinja2==2.10, freeze pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
               'colorama==0.3.7',
               'docutils==0.13.1',
               'enum34==1.1.6',
-              'Jinja2==2.9.6',
+              'Jinja2==2.10',
               'lxml==3.7.3',
               'packaging==16.8',
               'raven==6.0.0',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 codecov==2.0.15
 flake8==3.4.1
 hypothesis==3.45.4
+pylint==1.9.2
 pytest-pylint==0.7.1
 pytest-flake8==0.8.1
 pytest-cov==2.5.1


### PR DESCRIPTION
Some of the modules we use require Jinja2 >= 2.10 now. Freezing pylint to latest version which supports python 2.x also.

Tests pass, not sure what else to check.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>