### PR TITLE
logging: use find instead of index when looking for new-line

### DIFF
--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -91,7 +91,7 @@ def verbose_logger(self, message, *args, **kwargs):
         hint = message
 
     else:
-        new_line_index = message.index('\n')
+        new_line_index = message.find('\n')
 
         if new_line_index == -1:
             hint = '{}...'.format(message[0:keep_len])


### PR DESCRIPTION
`index` raises an exception, while `find` returns -1 - by mistake, `index` was used.