### PR TITLE
Support variables and templates in pattern maps

### DIFF
--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -1064,7 +1064,16 @@ def _load_yaml_variables(data, enabled=True, logger=None):
         context.update(load_yaml(variables_map_path, logger=logger))
 
     def _render_template(s):
-        return render_template(s, logger=logger, **context)
+        if isinstance(s, str):
+            return render_template(s, logger=logger, **context)
+
+        if isinstance(s, list):
+            return [
+                render_template(t, logger=logger, **context)
+                for t in s
+            ]
+
+        raise GlueError("Don't know how to render object of type {}".format(type(s)))
 
     return _render_template
 
@@ -1109,6 +1118,8 @@ class SimplePatternMap(object):
             # Apply variables if requested.
             pattern = _render_template(pattern)
             result = _render_template(result)
+
+            log_dict(logger.debug, "rendered mapping '{}'".format(pattern), result)
 
             try:
                 pattern = re.compile(pattern)
@@ -1241,6 +1252,8 @@ class PatternMap(object):
             # Apply variables if requested.
             pattern = _render_template(pattern_key)
             converter_chains = _render_template(pattern_dict[pattern_key])
+
+            log_dict(logger.debug, "rendered mapping '{}'".format(pattern), converter_chains)
 
             if isinstance(converter_chains, str):
                 converter_chains = [converter_chains]

--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -1086,7 +1086,7 @@ class SimplePatternMap(object):
         ``# !include <path>``, where path refers to a YAML file providing the necessary variables.
     """
 
-    def __init__(self, filepath, logger=None, allow_variables=True):
+    def __init__(self, filepath, logger=None, allow_variables=False):
         self.logger = logger or Logging.get_logger()
         logger.connect(self)
 

--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -1197,7 +1197,7 @@ class PatternMap(object):
         ``# !include <path>``, where path refers to a YAML file providing the necessary variables.
     """
 
-    def __init__(self, filepath, spices=None, logger=None, allow_variables=True):
+    def __init__(self, filepath, spices=None, logger=None, allow_variables=False):
         self.logger = logger or Logging.get_logger()
         logger.connect(self)
 

--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -1017,7 +1017,7 @@ def load_json(filepath, logger=None):
 def _load_yaml_variables(data, enabled=True, logger=None):
     """
     Load all variables from files referenced by a YAML, and return function to render a string
-    as a template using this variables. The files containing variables are mentioned in comments,
+    as a template using these variables. The files containing variables are mentioned in comments,
     in a form ``# !include <filepath>`` form.
 
     :param data: data loaded from a YAML file.
@@ -1029,14 +1029,19 @@ def _load_yaml_variables(data, enabled=True, logger=None):
 
     logger = logger or Logging.get_logger()
 
+    def _render_template_nop(s):
+        return s
+
+    if not enabled:
+        return _render_template_nop
+
     # Our YAML reader preserves comments, they are accessible via `ca` attribute of the
     # YAML data structure (which behaves like a dict or list, but it has additional
     # powers).
-    if not enabled or not hasattr(data, 'ca') or not hasattr(data.ca, 'comment') or len(data.ca.comment) <= 1:
-        def _render_template(s):
-            return s
+    if not hasattr(data, 'ca') or not hasattr(data.ca, 'comment') or len(data.ca.comment) <= 1:
+        logger.debug('when looking for !import directives, no comments found in YAML data')
 
-        return _render_template
+        return _render_template_nop
 
     # Ok, so this YAML data contains comments. Check their values to find `!include` directives.
     # Load referenced files and merged them into a single context.


### PR DESCRIPTION
Add support for rendering both sides of mapping entries, usign variables
automaticaly imported from files, referenced by special comments.

The example bellow would map ``a pattern used in many files`` to ``meh``.

map.yml:

```yaml
---

"{{ foo.bar }}": "{{ baz }}"
```

vars.yml:

```yaml
---

foo:
  bar: "a pattern used in many files"

baz: meh
```