### PR TITLE
When raising GlueError, let site specify Sentry fingerprint and tags

### DIFF
--- a/gluetool/tests/test_error.py
+++ b/gluetool/tests/test_error.py
@@ -3,7 +3,7 @@ import types
 
 import pytest
 from mock import MagicMock
-from hypothesis import assume, example, given, strategies as st
+from hypothesis import example, given, strategies as st
 
 import gluetool
 from gluetool import GlueError

--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -1500,7 +1500,7 @@ class PatternMap(object):
                 converter(pattern, s) for converter in converters
             ]
 
-        raise GlueError("Could not match string '{}' with any pattern".format(s))
+        raise GlueError("Could not match string '{}' with any pattern".format(s), sentry_fingerprint=[s])
 
 
 def wait(label, check, timeout=None, tick=30, logger=None):


### PR DESCRIPTION
This complements ``sentry_fingerprint`` and ``sentry_tags`` methods of the ``GlueError`` class and lets users specify these values without a need of extra class, which is sometimes an overkill.