### PR TITLE
Module discovery refactored a bit, adding entry point support

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -1692,7 +1692,7 @@ class Glue(Configurable):
         return pm
 
     def _discover_gm_in_file(self, registry, filepath, pm_name, group_name):
-        # type: (Dict[str, DiscoveredModule], str, str, str) -> None
+        # type: (ModuleRegistryType, str, str, str) -> None
         """
         Discover ``gluetool`` modules in a file.
 
@@ -1755,7 +1755,7 @@ class Glue(Configurable):
                 self._discover_gm_in_file(registry, os.path.join(root, filename), pm_name, group_name)
 
     def _discover_gm_in_entry_point(self, entry_point, registry):
-        # type: (str, Dict[str, DiscoveredModule]) -> None
+        # type: (str, ModuleRegistryType) -> None
 
         self.debug('discovering modules in entry point {}'.format(entry_point))
 
@@ -1765,7 +1765,7 @@ class Glue(Configurable):
             self._register_module(registry, getattr(klass, 'group', ''), klass, ep_entry.dist.location)
 
     def discover_modules(self, entry_points=None, paths=None):
-        # type: (Optional[List[str]], Optional[List[str]]) -> Dict[str, DiscoveredModule]
+        # type: (Optional[List[str]], Optional[List[str]]) -> ModuleRegistryType
         """
         Discover and load all accessible modules.
 
@@ -1788,7 +1788,7 @@ class Glue(Configurable):
         log_dict(self.debug, 'discovering modules under following entry points', entry_points)
         log_dict(self.debug, 'discovering modules under following paths', paths)
 
-        modules_registry = {}  # type: Dict[str, DiscoveredModule]
+        modules_registry = {}  # type: ModuleRegistryType
 
         for entry_point in entry_points:
             self._discover_gm_in_entry_point(entry_point, modules_registry)
@@ -2078,7 +2078,7 @@ class Glue(Configurable):
 
         modules = modules or self.modules
 
-        groups = collections.defaultdict(dict)  # type: Dict[str, Dict[str, DiscoveredModule]]
+        groups = collections.defaultdict(dict)  # type: Dict[str, ModuleRegistryType]
 
         for name, module_info in modules.iteritems():
             groups[module_info.group][name] = module_info
@@ -2100,6 +2100,7 @@ class Glue(Configurable):
 
         as_groups = self.modules_as_groups(modules=modules)
 
+        # List of lines, will be merged with `\n` before printing.
         descriptions = []  # type: List[str]
 
         if groups:

--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -2142,6 +2142,8 @@ class Glue(Configurable):
                     continue
 
                 for module_name, module in sorted(group.iteritems()):
-                    descriptions.append('%-4s%-32s %s' % ('', module_name, module.klass.description))
+                    # Indent module name by 4 spaces, and reserve 32 characters for each module name,
+                    # starting all descriptions at the same offset.
+                    descriptions.append('    {:32} {}'.format(module_name, module.klass.description))
 
         return '\n'.join(descriptions)

--- a/gluetool/tests/test_core.py
+++ b/gluetool/tests/test_core.py
@@ -98,7 +98,7 @@ def test_check_module_file(log, tmpdir):
         mfile.write(file_content)
 
         log.clear()
-        assert glue._check_module_file(str(mfile)) is True
+        assert glue._check_pm_file(str(mfile)) is True
         assert log.records[0].message == "check possible module file '{}'".format(mfile)
         assert log.records[0].levelno == logging.DEBUG
 
@@ -106,7 +106,7 @@ def test_check_module_file(log, tmpdir):
         mfile.write(file_content)
 
         log.clear()
-        assert glue._check_module_file(str(mfile)) is False
+        assert glue._check_pm_file(str(mfile)) is False
         assert log.records[0].message == "check possible module file '{}'".format(mfile)
         assert log.records[0].levelno == logging.DEBUG
         assert log.records[1].message == error

--- a/gluetool/tests/test_module_discovery.py
+++ b/gluetool/tests/test_module_discovery.py
@@ -1,0 +1,137 @@
+# pylint: disable=blacklisted-name
+
+import logging
+import pytest
+
+import gluetool
+
+
+@pytest.fixture(name='glue')
+def fixture_glue():
+    return gluetool.Glue()
+
+
+def _assert_module_registered(log, glue, registry, klass, name, group):
+    assert name in registry
+    assert registry[name].klass is klass
+    assert registry[name].group == group
+
+    assert log.match(message="registering module '{}' from dummy-filepath:{}".format(name, klass.__name__))
+
+
+def test_register_module(log, glue):
+    class DummyModule(gluetool.Module):
+        name = 'dummy-module'
+
+    registry = {}
+
+    glue._register_module(registry, 'dummy-group', DummyModule, 'dummy-filepath')
+
+    assert len(registry) == 1
+
+    _assert_module_registered(log, glue, registry, DummyModule, 'dummy-module', 'dummy-group')
+
+
+def test_register_module_aliases(log, glue):
+    class DummyModule(gluetool.Module):
+        name = ('dummy-module', 'dummy-module-alias')
+
+    registry = {}
+
+    glue._register_module(registry, 'dummy-group', DummyModule, 'dummy-filepath')
+
+    assert len(registry) == 2
+
+    _assert_module_registered(log, glue, registry, DummyModule, 'dummy-module', 'dummy-group')
+    _assert_module_registered(log, glue, registry, DummyModule, 'dummy-module-alias', 'dummy-group')
+
+
+def test_register_module_no_names(log, glue):
+    class DummyModule(gluetool.Module):
+        pass
+
+    registry = {}
+
+    with pytest.raises(gluetool.GlueError, match=r'No name specified by module class dummy-filepath:DummyModule'):
+        glue._register_module(registry, 'dummy-group', DummyModule, 'dummy-filepath')
+
+
+def test_register_module_name_conflict(log, glue):
+    class DummyModule(gluetool.Module):
+        name = 'dummy-module'
+
+    registry = {
+        'dummy-module': None
+    }
+
+    with pytest.raises(gluetool.GlueError, match=r"Name 'dummy-module' of class dummy-filepath:DummyModule is a duplicate module name"):
+        glue._register_module(registry, 'dummy-group', DummyModule, 'dummy-filepath')
+
+
+@pytest.mark.parametrize(
+    ('expected', 'error_message', 'content'),
+    (
+        # Empty Python file
+        (False, "  no 'import gluetool' found", 'pass'),
+
+        # Check file that imports gluetool but does not have module class
+        (False, '  no child of gluetool.Module found', 'import gluetool'),
+        (False, '  no child of gluetool.Module found', 'from gluetool import Glue'),
+
+        # Check we ignore module classes with wrong base class
+        (False, '  no child of gluetool.Module found', """
+import gluetool
+
+class DummyModule(object):
+    pass
+"""),
+
+        # Check file that does have module class, but that does not import gluetool
+        (False, "  no 'import gluetool' found", """
+class DummyModule(gluetool.Module):
+    pass
+"""),
+
+        # Check file that both imports gluetool, and has module class
+        (True, '', """
+import gluetool
+
+class DummyModule(gluetool.Module):
+    pass
+"""),
+
+        (True, '', """
+from gluetool import Module
+
+class DummyModule(Module):
+    pass
+"""),
+
+        # Check if module can have multiple names
+        (True, '', """
+from gluetool import Module
+
+class DummyModule(Module):
+    name = ['dummy', 'dummy-alias']
+""")
+    )
+)
+def test_check_pm_file(log, tmpdir, glue, expected, error_message, content):
+    # pylint: disable=protected-access
+
+    pm_file = tmpdir.join('dummy.py')
+    pm_file.write(content)
+
+    log.clear()
+
+    assert glue._check_pm_file(str(pm_file)) is expected
+
+    assert log.match(levelno=logging.DEBUG, message="check possible module file '{}'".format(pm_file))
+
+    if expected is False:
+        assert log.match(levelno=logging.DEBUG, message=error_message)
+
+
+def test_check_pm_file_missing(log, tmpdir, glue):
+    with pytest.raises(gluetool.GlueError, match=r"Unable to check check module file 'foo\.txt': \[Errno 2\] No such file or directory: 'foo\.txt'"):
+        glue._check_pm_file('foo.txt')

--- a/gluetool/tests/test_run_modules.py
+++ b/gluetool/tests/test_run_modules.py
@@ -35,17 +35,15 @@ def fixture_glue():
     glue = NonLoadingGlue()
 
     # register our dummy module classes
-    glue.modules['Dummy module'] = {
-        'class': DummyModule,
-        'description': DummyModule.__doc__,
-        'group': 'none'
-    }
+    glue.modules['Dummy module'] = gluetool.glue.DiscoveredModule(
+        klass=DummyModule,
+        group='none'
+    )
 
-    glue.modules['Broken module'] = {
-        'class': BrokenModule,
-        'description': BrokenModule.__doc__,
-        'group': 'none'
-    }
+    glue.modules['Broken module'] = gluetool.glue.DiscoveredModule(
+        klass=BrokenModule,
+        group='none'
+    )
 
     return glue
 


### PR DESCRIPTION
No matter where we want to go from now, we have to support Pythonic way
of discovering and loading of modules, which is using entry points for
Python packages to attach Gluetool modules to. At the same time we have
to support the current method (let's call it "legacy") of discovering
modules by searching directory trees for suitable Python files.

Patch clears few things a bit, like names of methods and the code flow,
makes other parts more explicit, e.g. discovered module representation.