### PR TITLE
When pipeline encouters exception, make a note before proceeding

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -660,6 +660,8 @@ class Pipeline(object):
             except Exception as exc:  # noqa
                 exc_info = sys.exc_info()
 
+                module.error('Exception raised: {}'.format(exc_info[1]))
+
                 module.add_shared()
 
                 six.reraise(*exc_info)

--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -202,10 +202,10 @@ class Gluetool(object):
         exit_status = 0 if failure.soft is True else -1
 
         if failure.module:
-            msg = "Exception raised in module '{}': {}".format(failure.module.unique_name, failure.exc_info[1].message)
+            msg = "Pipeline reported an exception in module '{}': {}".format(failure.module.unique_name, failure.exc_info[1].message)
 
         else:
-            msg = "Exception raised: {}".format(failure.exc_info[1].message)
+            msg = "Pipeline reported an exception: {}".format(failure.exc_info[1].message)
 
         logger.error(msg, exc_info=failure.exc_info)
 


### PR DESCRIPTION
Previous version of pipeline let the exception bubble up to the tool
which logged it and began "destroy" stage. Current version of pipeline
code catches the exception, begans the "destroy" stage, and returns the
exception to the caller. It works, but the side-effect is that the
exception is logged by the caller (tool in the case of the main
pipeline), which happens at the very end of the pipeline - it is quite
hard to spot in the log *where* the exception happened since its log is
at the end of the output no matter what.

So, this patch adds one `error` call when pipeline encouters the
exception, and slightly changes wording of the final "log the error"
message - we want tool to log it anyway, but that would mean it's logged
twice, hence the final message should have a bit more global-ish sound.