### PR TITLE
Simple Result class for wrapping results and errors

### DIFF
--- a/gluetool/__init__.py
+++ b/gluetool/__init__.py
@@ -1,7 +1,9 @@
 from .glue import Glue, Module
 from .glue import GlueError, SoftGlueError, GlueRetryError, GlueCommandError, Failure
+from .result import Result, Ok, Error
 from . import utils
 
 __all__ = ['Glue', 'Module',
            'GlueError', 'SoftGlueError', 'GlueRetryError', 'GlueCommandError', 'Failure',
+           'Result', 'Ok', 'Error',
            'utils']

--- a/gluetool/result.py
+++ b/gluetool/result.py
@@ -1,0 +1,183 @@
+# Type annotations
+# pylint: disable=unused-import,wrong-import-order
+from typing import cast, Any, Generic, Optional, TypeVar, Union  # noqa
+
+
+#
+# Result and its handling.
+#
+#
+# A ``Result`` can be either ``Ok(value)`` - valid result, contains a meaningful
+# value - or ``Error(error)`` which represents an error, carrying error's description.
+#
+
+# T represents the type of valid value...
+T = TypeVar("T")
+# ... and E represents type of the error description.
+E = TypeVar("E")
+
+
+class Result(Generic[T, E]):
+    """
+    A simple `Result` type inspired by Rust.
+
+    A ``Result`` can be either ``Ok(value)`` - valid result, contains a meaningful
+    value - or ``Error(error)`` which represents an error, carrying error's description.
+
+    :param bool _is_ok: ``True`` when the ``_value`` is OK-ish.
+    :param _value: the value carried by the result.
+    :param bool _force: guards against accidental direct use.
+    """
+
+    def __init__(self, _is_ok, _value, _force=False):
+        # type: (bool, Union[T, E], bool) -> None
+        """
+        .. warning::
+
+           Do not instantiate ``Result`` instrances directly, **always** use either
+           :py:func:`Ok` or :py:func:`Error` functions. Othwerise, type guarantees
+           cannot be given.
+        """
+
+        if not _force:
+            raise RuntimeError('Do not instantiate Result objects directly.')
+
+        self._is_ok = _is_ok
+        self._value = _value
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        # pylint: disable=protected-access
+
+        return (self.__class__ == other.__class__ and
+                self.is_ok == cast(Result, other).is_ok and
+                self._value == other._value)
+
+    def __ne__(self, other):
+        # type: (Any) -> bool
+
+        return not self == other
+
+    def __hash__(self):
+        # type: () -> int
+
+        return hash((self.is_ok, self._value))
+
+    def __repr__(self):
+        # type: () -> str
+
+        if self.is_ok:
+            return 'Ok({})'.format(repr(self._value))
+
+        return 'Err({})'.format(repr(self._value))
+
+    # pylint: disable=invalid-name
+    @classmethod
+    def Ok(cls, value):
+        # type: (T) -> Result[T, E]
+
+        return cls(_is_ok=True, _value=value, _force=True)
+
+    # pylint: disable=invalid-name
+    @classmethod
+    def Error(cls, error):
+        # type: (E) -> Result[T, E]
+
+        return cls(_is_ok=False, _value=error, _force=True)
+
+    @property
+    def is_ok(self):
+        # type: () -> bool
+
+        return self._is_ok
+
+    @property
+    def is_error(self):
+        # type: () -> bool
+        """
+        Returns ``True`` if the result value is invalid.
+        """
+
+        return not self._is_ok
+
+    # pylint: disable=invalid-name
+    @property
+    def ok(self):
+        # type: () -> Optional[T]
+        """
+        Return the result value - valid - if it is valid. Otherwise,
+        ``None`` is returned.
+        """
+
+        return cast(T, self._value) if self.is_ok else None
+
+    @property
+    def error(self):
+        # type: () -> Optional[E]
+        """
+        Return the result value - error - if it is invalid. Otherwise, ``None``
+        is returned.
+        """
+
+        return cast(E, self._value) if self.is_error else None
+
+    @property
+    def value(self):
+        # type: () -> Union[T, E]
+        """
+        Return the result value. It will be either one of valid and error types.
+        """
+
+        return self._value
+
+    def expect(self, message):
+        # type: (str) -> T
+        """
+        Return the result value if it is valid. Otherwise, an exception is raised.
+        Return the value if it is an `Ok` type. Raises an `UnwrapError` if it is an `Err`.
+        """
+
+        if self.is_ok:
+            return cast(T, self._value)
+
+        # Avoiding cyclic imports...
+        # pylint: disable=cyclic-import
+        from .glue import GlueError
+
+        raise GlueError(message)
+
+    def unwrap(self):
+        # type: () -> T
+        """
+        Return the result value if it is valid. Otherwise, an exception is rised.
+        """
+
+        return self.expect('Expected valid result value, found error')
+
+    def unwrap_or(self, default):
+        # type: (T) -> T
+        """
+        Return the result value if it is valid. Otherwise, ``default`` is returned.
+        """
+
+        if self.is_ok:
+            return cast(T, self._value)
+
+        return default
+
+
+# pylint: disable=invalid-name
+def Ok(value):
+    # type: (T) -> Result[T, E]
+
+    return Result.Ok(value)
+
+
+# pylint: disable=invalid-name
+def Error(error):
+    # type: (E) -> Result[T, E]
+    """
+    Shortcut function to create a new Result.
+    """
+
+    return Result.Error(error)

--- a/gluetool/result.py
+++ b/gluetool/result.py
@@ -34,8 +34,8 @@ class Result(Generic[T, E]):
         """
         .. warning::
 
-           Do not instantiate ``Result`` instrances directly, **always** use either
-           :py:func:`Ok` or :py:func:`Error` functions. Othwerise, type guarantees
+           Do not instantiate ``Result`` instances directly, **always** use either
+           :py:func:`Ok` or :py:func:`Error` functions. Otherwise, type guarantees
            cannot be given.
         """
 
@@ -69,7 +69,7 @@ class Result(Generic[T, E]):
         if self.is_ok:
             return 'Ok({})'.format(repr(self._value))
 
-        return 'Err({})'.format(repr(self._value))
+        return 'Error({})'.format(repr(self._value))
 
     # pylint: disable=invalid-name
     @classmethod
@@ -134,7 +134,6 @@ class Result(Generic[T, E]):
         # type: (str) -> T
         """
         Return the result value if it is valid. Otherwise, an exception is raised.
-        Return the value if it is an `Ok` type. Raises an `UnwrapError` if it is an `Err`.
         """
 
         if self.is_ok:
@@ -169,6 +168,9 @@ class Result(Generic[T, E]):
 # pylint: disable=invalid-name
 def Ok(value):
     # type: (T) -> Result[T, E]
+    """
+    Shortcut function to create a new valid Result.
+    """
 
     return Result.Ok(value)
 
@@ -177,7 +179,7 @@ def Ok(value):
 def Error(error):
     # type: (E) -> Result[T, E]
     """
-    Shortcut function to create a new Result.
+    Shortcut function to create a new error Result.
     """
 
     return Result.Error(error)

--- a/gluetool/tests/test_result.py
+++ b/gluetool/tests/test_result.py
@@ -1,0 +1,83 @@
+import pytest
+
+import gluetool
+from gluetool.result import Result, Ok, Error
+
+
+@pytest.mark.parametrize('result, value, is_ok', [
+    (Ok(1), 1, True),
+    (Result.Ok(1), 1, True),
+    (Ok(True), True, True),
+    (Ok(False), False, True),
+    (Error(1), 1, False),
+    (Result.Error(1), 1, False),
+    (Error(True), True, False)
+])
+def test_factory(result, value, is_ok):
+    assert result._value == value
+    assert result.is_ok is is_ok
+    assert result.is_error is not is_ok
+
+
+def test_eq():
+    assert Ok(1) == Ok(1)
+    assert Error(1) == Error(1)
+    assert Ok(1) != Error(1)
+    assert Ok(1) != Ok(2)
+    assert not (Ok(1) != Ok(1))
+    assert Ok(1) != 'foo'
+    assert Ok('0') != Ok(0)
+
+
+def test_hash():
+    assert len({Ok(1), Error('2'), Ok(1), Error('2')}) == 2
+    assert len({Ok(1), Ok(2)}) == 2
+    assert len({Ok('a'), Error('a')}) == 2
+
+
+def test_ok_value():
+    o = Ok('foo')
+    n = Error('foo')
+    assert o.ok == 'foo'
+    assert n.ok is None
+
+
+def test_err_value():
+    o = Ok('foo')
+    n = Error('foo')
+    assert o.error is None
+    assert n.error == 'foo'
+
+
+def test_no_constructor():
+    with pytest.raises(RuntimeError):
+        Result(_is_ok=True, _value='foo')
+
+
+def test_unwrap():
+    o = Ok('foo')
+    n = Error('foo')
+
+    assert o.unwrap() == 'foo'
+
+    with pytest.raises(gluetool.GlueError):
+        n.unwrap()
+
+
+def test_expect():
+    o = Ok('foo')
+    n = Error('foo')
+
+    assert o.expect('failure') == 'foo'
+
+    with pytest.raises(gluetool.GlueError):
+        n.expect('failure')
+
+
+def test_unwrap_or():
+    o = Ok('foo')
+    n = Error('foo')
+
+    assert o.unwrap_or('default value') == 'foo'
+    assert n.unwrap_or('default value') == 'default value'
+

--- a/gluetool/tests/test_wait.py
+++ b/gluetool/tests/test_wait.py
@@ -4,13 +4,29 @@ import pytest
 import gluetool
 import gluetool.utils
 
+from gluetool.result import Result, Ok, Error
 from gluetool.utils import wait
+
+# Type annotations
+# pylint: disable=unused-import, wrong-import-order
+from typing import Any, List  # noqa
 
 
 def test_sanity(log):
-    return_values = [False, False, True]
+    # type: (Any) -> None
 
-    wait('dummy check', lambda: return_values.pop(0), timeout=10, tick=2)
+    return_values = [
+        Error('failed first time'),
+        Error('failed second time'),
+        Ok('finally passed')
+    ]  # type: List[Result[str, str]]
+
+    def _check():
+        # type: () -> Result[str, str]
+
+        return return_values.pop(0)
+
+    wait('dummy check', _check, timeout=10, tick=2)
 
     assert len(log.records) == 9
 
@@ -18,10 +34,10 @@ def test_sanity(log):
     # pylint: disable=line-too-long
     assert re.match(r"waiting for condition 'dummy check', timeout \d seconds, check every 2 seconds", log.records[0].message) is not None  # Ignore PEP8Bear
     assert log.records[1].message == 'calling callback function'
-    assert log.records[2].message == 'check failed with False, assuming failure'
+    assert log.records[2].message == 'check failed with \'failed first time\', assuming failure'
     assert re.match(r'\d seconds left, sleeping for 2 seconds$', log.records[3].message) is not None
     assert log.records[4].message == 'calling callback function'
-    assert log.records[5].message == 'check failed with False, assuming failure'
+    assert log.records[5].message == 'check failed with \'failed second time\', assuming failure'
     assert re.match(r'\d seconds left, sleeping for 2 seconds$', log.records[6].message) is not None
     assert log.records[7].message == 'calling callback function'
     assert log.records[8].message == 'check passed, assuming success'
@@ -29,7 +45,7 @@ def test_sanity(log):
 
 def test_timeout():
     with pytest.raises(gluetool.GlueError, match=r"Condition 'dummy check' failed to pass within given time"):
-        wait('dummy check', lambda: False, timeout=2, tick=1)
+        wait('dummy check', lambda: Error('never going to pass'), timeout=2, tick=1)
 
 
 def test_invalid_tick():


### PR DESCRIPTION
Very useful for callbacks and other result-oriented code. Instead of
raising an exception, function always returns "something", a Result
instance, which is either "Ok" or "Error". Removes exception raising,
gives us more type safety and more readable handling of errors.