### PR TITLE
Simplify pipeline handling of execute and destroy

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -606,7 +606,7 @@ class Pipeline(object):
     def _log_failure(self, module, failure, label):
         # type: (Module, Failure, str) -> None
         """
-        Log a failure, and submit it to the Sentry.
+        Log a failure, and submit it to Sentry.
 
         :param Module module: module to use for logging - apparently, the failure appeared
             when this module was running.

--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -221,7 +221,7 @@ class Gluetool(object):
         logger.error(msg, exc_info=failure.exc_info)
 
         # Submit what hasn't been submitted yet...
-        if self.sentry is not None and failure.sentry_event_id is None:
+        if self.sentry and not failure.sentry_event_id:
             self.sentry.submit_exception(failure, logger=logger)
 
         self._quit(exit_status)

--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -220,7 +220,8 @@ class Gluetool(object):
 
         logger.error(msg, exc_info=failure.exc_info)
 
-        if self.sentry is not None:
+        # Submit what hasn't been submitted yet...
+        if self.sentry is not None and failure.sentry_event_id is None:
             self.sentry.submit_exception(failure, logger=logger)
 
         self._quit(exit_status)


### PR DESCRIPTION
It was way too complicated. Using _safe_call and extra helper for
logging of failures simplifies the relevant code a lot, making it more
streamlined and readable.

This also fixes re-submission of failures to the Sentry which
effectively reset failures' Sentry event ID after some point of
workflow.