### PR TITLE
LoggerMixin instead of logger.connect()

### DIFF
--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -563,20 +563,23 @@ class ContextAdapter(logging.LoggerAdapter):
         self.log(logging.DEBUG, placeholder_message, exc_info=exc_info, extra=extra, sentry=sentry)
         self.log(VERBOSE, msg, exc_info=exc_info, extra=extra, sentry=sentry)
 
+    # Disabling type checking of logging methods' signatures - they differ from supertype's signatures
+    # but that is on purpose.
+
     # pylint: disable=arguments-differ
-    def debug(self, msg, exc_info=None, extra=None, sentry=False):  # type: ignore  # Signature of "debug" incompatible with supertype "LoggerAdapter"
+    def debug(self, msg, exc_info=None, extra=None, sentry=False):  # type: ignore
         # type: (str, Optional[ExceptionInfoType], Optional[Dict[str, Any]], bool) -> None
 
         self.log(logging.DEBUG, msg, exc_info=exc_info, extra=extra, sentry=sentry)
 
     # pylint: disable=arguments-differ
-    def info(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore  # Signature of "debug" incompatible with supertype "LoggerAdapter"
+    def info(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore
         # type: (str, Optional[ExceptionInfoType], Optional[Dict[str, Any]], bool) -> None
 
         self.log(logging.INFO, msg, exc_info=exc_info, extra=extra, sentry=sentry)
 
     # pylint: disable=arguments-differ
-    def warning(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore  # Signature of "debug" incompatible with supertype "LoggerAdapter"
+    def warning(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore
         # type: (str, Optional[ExceptionInfoType], Optional[Dict[str, Any]], bool) -> None
 
         self.log(logging.WARNING, msg, exc_info=exc_info, extra=extra, sentry=sentry)
@@ -584,13 +587,13 @@ class ContextAdapter(logging.LoggerAdapter):
     warn = warning
 
     # pylint: disable=arguments-differ
-    def error(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore  # Signature of "debug" incompatible with supertype "LoggerAdapter"
+    def error(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore
         # type: (str, Optional[ExceptionInfoType], Optional[Dict[str, Any]], bool) -> None
 
         self.log(logging.ERROR, msg, exc_info=exc_info, extra=extra, sentry=sentry)
 
     # pylint: disable=arguments-differ
-    def exception(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore  # Signature of "debug" incompatible with supertype "LoggerAdapter"
+    def exception(self, msg, exc_info=None, extra=None, sentry=False):   # type: ignore
         # type: (str, Optional[ExceptionInfoType], Optional[Dict[str, Any]], bool) -> None
 
         self.log(logging.ERROR, msg, exc_info=exc_info, extra=extra, sentry=sentry)

--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -628,6 +628,11 @@ class LoggerMixin(object):
     def __init__(self, logger):
         # type: (ContextAdapter) -> None
 
+        self._reconnect_logger(logger)
+
+    def _reconnect_logger(self, logger):
+        # type: (ContextAdapter) -> None
+
         self.logger = logger
 
         self.log = logger.log

--- a/gluetool/tests/conftest.py
+++ b/gluetool/tests/conftest.py
@@ -14,7 +14,7 @@ def fixture_enable_logger():
     but we don't have such luxury in the ``gluetool`` unit tests.
     """
 
-    return gluetool.log.Logging.create_logger()
+    return gluetool.log.Logging.setup_logger()
 
 
 @pytest.fixture(name='enable_logger_propagate', scope='session', autouse=True)
@@ -24,7 +24,7 @@ def fixture_enable_logger_propagate():
     not work as it sets up another logger, capturing messages propagated by our "real" loggers.
     """
 
-    gluetool.log.Logging.create_logger()
+    gluetool.log.Logging.setup_logger()
     gluetool.log.Logging.logger.propagate = True
 
 

--- a/gluetool/tests/test_help.py
+++ b/gluetool/tests/test_help.py
@@ -42,7 +42,7 @@ def test_extract_eval_context_info_missing():
 
 
 def test_extract_eval_context_info_unchanged():
-    class DummyModule(gluetool.glue.Configurable):
+    class DummyModule(object):
         name = 'dummy-module'
 
         @property

--- a/gluetool/tests/test_json.py
+++ b/gluetool/tests/test_json.py
@@ -44,7 +44,7 @@ def test_load(json_data, log, tmpdir):
     loaded = load_json(filepath)
 
     assert json_data == loaded
-    assert log.match(message="loaded JSON data from '{}':\n{}".format(filepath, gluetool.utils.format_dict(json_data)))
+    assert log.match(message="loaded JSON data from '{}':\n{}".format(filepath, gluetool.log.format_dict(json_data)))
 
 
 def test_error(tmpdir):

--- a/gluetool/tests/test_load_yaml.py
+++ b/gluetool/tests/test_load_yaml.py
@@ -3,7 +3,8 @@ import re
 import pytest
 
 from gluetool import GlueError
-from gluetool.utils import load_yaml, format_dict
+from gluetool.log import format_dict
+from gluetool.utils import load_yaml
 
 from . import create_yaml
 

--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -440,7 +440,7 @@ class Gluetool(object):
                 return failure, destroy_failure
 
             if failure and isinstance(failure.exception, GlueRetryError):
-                Glue.error(failure.exception)
+                Glue.error(str(failure.exception))
                 continue
 
             return failure, destroy_failure

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
               'Jinja2==2.10',
               'lxml==4.2.4',
               'mock==3.0.5',
+              'mypy-extensions==0.4.1',
               'packaging==17.1',
               'raven==6.9.0',
               'requests==2.19.1',


### PR DESCRIPTION
Using a mixin class we can get rid of "logging type stubs" because,
suddenly, all logging methods are inherited from the mixin class \o/

It required few tweaks to get there - our ContextAdapter gained its own
set of logging methods, overloading those inherited from its parent
class, because 1) logging's idea about signature of these methods didn't
play well with exception info returned by sys.exc_info(), and 2) we like
our sentry=True parameter to submit warnings.

So, LoggerMixin is used to bring methods to classes. Sentry's "submit
warning" become "submit message" because it's no longer just a warning,
sentry parameter is supported everywhere - this and explicitly stating
that ContextAdapter is our main logging vehicle let's us get rid of
patching logging with our versions of warn() and verbose(). All our code
is using ContextAdapter and its children, attaching their methods to
classes via LoggerMixin, and Logger instances used by 3rd party
libraries are simply redirected to our handlers.

Things are much simler now, so happy, such wow.