### PR TITLE
`CallbackModule` add required methods

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -1423,6 +1423,24 @@ class CallbackModule(mock.MagicMock):  # type: ignore  # MagicMock has type Any,
 
         self._callback(self.glue, *self._args, **self._kwargs)
 
+    def sanity(self):
+        # type: () -> None
+
+        # pylint: disable-msg=no-self-use
+        return None
+
+    def destroy(self, failure=None):
+        # type: (Optional[Failure]) -> None
+
+        # pylint: disable-msg=no-self-use,unused-argument
+        return None
+
+    def check_required_options(self):
+        # type: () -> None
+
+        # pylint: disable-msg=no-self-use
+        return None
+
 
 class Module(Configurable):
     """

--- a/gluetool/tests/test_core.py
+++ b/gluetool/tests/test_core.py
@@ -6,6 +6,7 @@ import pytest
 import gluetool
 
 from . import NonLoadingGlue
+from mock import MagicMock
 
 
 def test_check_for_commands():
@@ -188,3 +189,22 @@ def test_module_instantiate():
     assert not mod._config
 
     assert mod.data_path is None  # There's no data path for our "Dummy module"
+
+
+def test_callback_module_instantiate():
+    """
+    Try to instantiate a callback module, and check some of its properties.
+    """
+
+    glue = NonLoadingGlue()
+
+    name = 'module'
+    callback = MagicMock()
+
+    mod = gluetool.glue.CallbackModule(name, glue, callback)
+
+    assert mod.glue == glue
+    assert mod.name == name
+
+    mod.execute()
+    callback.assert_called_once()


### PR DESCRIPTION
In case these methos are not implemented and are called by gluetool, `CallbackModule` returns
`MagicMock` object, it is handled as failure (because it is not `None`) and pipeline fails.