### PR TITLE
Dropping setuptools-scm versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ from setuptools import setup
 
 if __name__ == '__main__':
     setup(name='gluetool',
-          setup_requires=['setuptools_scm'],
-          use_scm_version=True,
           packages=[
               'gluetool',
               'gluetool.pylint',


### PR DESCRIPTION
We are not really using it, and it complicates our relationship with pip by introducing easy_install to the game via setup_requires