### PR TITLE
gluetool/utils.py: Add 'regex_replace' filter

### DIFF
--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -66,6 +66,16 @@ if 'file' not in urlnormalizer.normalizer.SCHEMES:
     urlnormalizer.normalizer.SCHEMES = urlnormalizer.normalizer.SCHEMES + ('file',)
 
 
+# Jinja2 filter - regular expression replace
+def regex_replace(s, find, replace):
+    # type: (str, str, str) -> str
+    return re.sub(find, replace, s)
+
+
+# Jinja2 - register custom filters
+jinja2.defaults.DEFAULT_FILTERS['regex_replace'] = regex_replace
+
+
 def deprecated(func):
     # type: (Callable[..., Any]) -> Callable[..., Any]
 


### PR DESCRIPTION
Useful to do replaces based on regular expression, where the built-in 'replace'
is not sufficient.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>