### PR TITLE
Adds Result.expect_error/unwrap_error

### DIFF
--- a/gluetool/result.py
+++ b/gluetool/result.py
@@ -147,6 +147,21 @@ class Result(Generic[T, E]):
 
         raise GlueError(message)
 
+    def expect_error(self, message):
+        # type: (str) -> E
+        """
+        Return the result value if it is invalid. Otherwise, an exception is raised.
+        """
+
+        if self.is_error:
+            return cast(E, self._value)
+
+        # Avoiding cyclic imports...
+        # pylint: disable=cyclic-import
+        from .glue import GlueError
+
+        raise GlueError(message)
+
     def unwrap(self):
         # type: () -> T
         """
@@ -154,6 +169,14 @@ class Result(Generic[T, E]):
         """
 
         return self.expect('Expected valid result value, found error')
+
+    def unwrap_error(self):
+        # type: () -> E
+        """
+        Return the error value if the result is invalid. Othwerise, an exception is raised.
+        """
+
+        return self.expect_error('Expected invalid result value, found valid one')
 
     def unwrap_or(self, default):
         # type: (T) -> T

--- a/gluetool/tests/test_result.py
+++ b/gluetool/tests/test_result.py
@@ -64,6 +64,16 @@ def test_unwrap():
         n.unwrap()
 
 
+def test_unwrap_error():
+    o = Ok('foo')
+    n = Error('foo')
+
+    with pytest.raises(gluetool.GlueError):
+        o.unwrap_error()
+
+    assert n.unwrap_error() == 'foo'
+
+
 def test_expect():
     o = Ok('foo')
     n = Error('foo')
@@ -72,6 +82,16 @@ def test_expect():
 
     with pytest.raises(gluetool.GlueError):
         n.expect('failure')
+
+
+def test_expect_error():
+    o = Ok('foo')
+    n = Error('foo')
+
+    with pytest.raises(gluetool.GlueError):
+        o.expect_error('failure')
+
+    assert n.expect_error('failure') == 'foo'
 
 
 def test_unwrap_or():


### PR DESCRIPTION
To complement Result.unwrap: while `if r.is_ok: r.unwrap()` is perfectly
fine because it returns non-Optional valid value, we lack the same for
invalid results: in `if r.is_error: r.error`, `r.error` may be None, and
additional `assert r.error is not None` is required. Adding
`r.unwrap_error() -> E` to provide correctly typed value.