### PR TITLE
enum34 should be used only with Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
               'beautifulsoup4==4.6.3',
               'colorama==0.3.9',
               'docutils==0.14',
-              'enum34==1.1.6',
+              'enum34==1.1.6; python_version == "2.7"',
               'future==0.16.0',
               'Jinja2==2.10',
               'lxml==4.2.4',


### PR DESCRIPTION
And since we're supporting Python 3.6+ only, use environment condition
to disable installation of enum34 with anything other than Python 2.7.

This hould unblock the installability of Gluetool via Poetry -
unconditional installation of enum34 is breaking Poetry packaging skills
as it collides with standard library's enum package.