### PR TITLE
Support structured logging to stderr

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -2469,7 +2469,6 @@ class Glue(Configurable):
         else:
             level = logging.INFO
 
-        from .utils import normalize_bool_option
         switch_colors(normalize_bool_option(self.option('colors')))
 
         debug_file = self.option('debug-file')

--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -1768,6 +1768,12 @@ class Glue(Configurable):
                         """,
                 'default': None
             },
+            ('J', 'json-output'): {
+                'help': """
+                        If set, all log messages sent to the terminal are emitted as JSON structures.
+                        """,
+                'action': 'store_true'
+            },
             ('o', 'debug-file', 'output'): {
                 'help': 'Log messages with at least ``DEBUG`` level are sent to this file.'
             },
@@ -2419,6 +2425,8 @@ class Glue(Configurable):
     def parse_args(self, args):
         # type: (Any) -> None
 
+        from .utils import normalize_bool_option
+
         module_dirs = '\n'.join(['        - {}'.format(directory) for directory in DEFAULT_MODULE_PATHS])
         data_dirs = '\n'.join(['        - {}'.format(directory) for directory in [DEFAULT_DATA_PATH]])
         module_config_dirs = '\n'.join(['        - {}'.format(directory) for directory in DEFAULT_MODULE_CONFIG_PATHS])
@@ -2467,6 +2475,7 @@ class Glue(Configurable):
         debug_file = self.option('debug-file')
         verbose_file = self.option('verbose-file')
         json_file = self.option('json-file')
+        json_output = normalize_bool_option(self.option('json-output'))
 
         if debug_file and not verbose_file:
             verbose_file = '{}.verbose'.format(debug_file)
@@ -2476,6 +2485,7 @@ class Glue(Configurable):
             debug_file=debug_file,
             verbose_file=verbose_file,
             json_file=json_file,
+            json_output=json_output,
             sentry=self._sentry,
             show_traceback=normalize_bool_option(self.option('show-traceback'))
         )

--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -1079,6 +1079,7 @@ class Logging(object):
                      debug_file=None,  # type: Optional[str]
                      verbose_file=None,  # type: Optional[str]
                      json_file=None,  # type: Optional[str]
+                     json_output=False,  # type: bool
                      sentry=None,  # type: Optional[gluetool.sentry.Sentry]
                      show_traceback=False  # type: bool
                     ):  # noqa
@@ -1101,6 +1102,8 @@ class Logging(object):
             messages of ``VERBOSE`` log levels into this this file.
         :param str json_file: if set, all logging messages are sent to this file in a form
             of JSON structures.
+        :param bool json_output: if set, all logging messages sent to the terminal are emitted as
+            JSON structures.
         :param int level: desired log level. One of constants defined in :py:mod:`logging` module,
             e.g. :py:data:`logging.DEBUG` or :py:data:`logging.ERROR`.
         :param bool sentry: if set, logger will be augmented to send every log message to the Sentry
@@ -1129,7 +1132,11 @@ class Logging(object):
             list(map(Logging.configure_logger, Logging.OUR_LOGGERS))
 
         # set formatter
-        Logging.stderr_handler.setFormatter(LoggingFormatter())
+        if json_output:
+            Logging.stderr_handler.setFormatter(JSONLoggingFormatter())
+
+        else:
+            Logging.stderr_handler.setFormatter(LoggingFormatter())
 
         # set log level to new value
         Logging.stderr_handler.setLevel(level)


### PR DESCRIPTION
We already have a formatter for JSON output, used for --json-file, but
we might soon need structured output to terminal as well, given possible
use of Gluetool in OpenShift environment.