### PR TITLE
Refactor processing of logging message contexts

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -452,7 +452,7 @@ class PipelineAdapter(ContextAdapter):
     def __init__(self, logger, pipeline_name):
         # type: (ContextAdapter, str) -> None
 
-        super(PipelineAdapter, self).__init__(logger, {'ctx_pipeline_name': (5, pipeline_name)})
+        super(PipelineAdapter, self).__init__(logger, contexts={'pipeline_name': (5, pipeline_name)})
 
 
 class Pipeline(LoggerMixin, object):


### PR DESCRIPTION
Instead of adding `ctx_foo` fields to logging records, we add single
field, mapping named `contexts`, to hold contexts names and their
values.

This makes handling of contexts more clear, easier to read and debug.

To make things consistent, JSON logging also mentions contexts - this
wasn't the case, and while normal formatter emits contexts, JSON
formatter did not.