### PR TITLE
Dropping support for tools derived from tool.Gluetool

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -2459,6 +2459,7 @@ class Glue(Configurable):
 
         Supported environment variables:
 
+        * GLUETOOL_CONFIG_PATHS (string) - colon-separated list of gluetool configuration directories
         * GLUETOOL_TRACING_DISABLE - when set, tracing won't be enabled
         * GLUETOOL_TRACING_SERVICE_NAME (string) - name of the trace produced by tool execution
         * GLUETOOL_TRACING_REPORTING_HOST (string) - a hostname where tracing collector listens

--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -66,6 +66,11 @@ class Gluetool(object):
 
         self.gluetool_config_paths = DEFAULT_GLUETOOL_CONFIG_PATHS
 
+        if 'GLUETOOL_CONFIG_PATHS' in os.environ:
+            self.gluetool_config_paths = gluetool.utils.normalize_path_option(
+                os.environ['GLUETOOL_CONFIG_PATHS']
+            )
+
         self.sentry = None  # type: Optional[gluetool.sentry.Sentry]
         self.tracer = None  # type: Optional[gluetool.action.Tracer]
 
@@ -83,13 +88,6 @@ class Gluetool(object):
         from .version import __version__
 
         return ensure_str(__version__.strip())
-
-    @cached_property
-    def _command_name(self):
-        # type: () -> str
-
-        # pylint: disable=no-self-use
-        return 'gluetool'
 
     def _deduce_pipeline_desc(self, argv, modules):
         # type: (List[Any], List[str]) -> List[gluetool.glue.PipelineStepModule]
@@ -332,7 +330,7 @@ Will try to submit it to Sentry but giving up on everything else.
 
         # version
         if Glue.option('version'):
-            Glue.info('{} {}'.format(self._command_name, self._version))
+            Glue.info('gluetool {}'.format(self._version))
             sys.exit(0)
 
         GlueError.no_sentry_exceptions = normalize_multistring_option(Glue.option('no-sentry-exceptions'))


### PR DESCRIPTION
This idea didn't take off properly. All these tools actually want is to
extend the default list of paths where gluetool looks for its master
configuration file, and use different name when generating Bash
completion scripts.

Gluetool now understands GLUETOOL_CONFIG_PATHS env var, so we can write
a simple shell wrapper, exporting desired values, and bash-completion
module gained new option, --command-name.