### PR TITLE
Freeze isort

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,9 +2,9 @@
 codecov==2.0.15
 flake8==3.4.1
 hypothesis==4.57.1
+isort==4.3.21
 pylint==1.9.2
 mock==2.0.0
-pylint==1.9.2
 pytest-pylint==0.7.1
 pytest-flake8==0.8.1
 pytest-cov==2.5.1


### PR DESCRIPTION
isort 5.0+ is incompatible with pylint, and breaks test run.