### PR TITLE
typing should be used only with Python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
               'Sphinx==1.5.2',
               'sphinx-rtd-theme==0.4.1',
               'tabulate==0.8.2',
-              'typing==3.7.4',
+              'typing==3.7.4; python_version == "2.7"',
               'typing-extensions==3.7.4',
               'urlnormalizer==1.2.0',
               'pyparsing==2.3.0',


### PR DESCRIPTION
And since we're supporting Python 3.6+ only, use environment condition
to disable installation of enum34 with anything other than Python 2.7.

This module is provided by stdlib, and when installed by pip, it may
break other modules working with typing.