### PR TITLE
support Python 3.7 and 3.8

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ function-rgx = [a-z_][a-z0-9_]{2,40}$
 
 [MESSAGES CONTROL]
 # Re-enable these ASAP
-disable=missing-docstring,logging-format-interpolation,too-many-locals,duplicate-code,inconsistent-return-statements
+disable=missing-docstring,logging-format-interpolation,too-many-locals,duplicate-code,inconsistent-return-statements,useless-object-inheritance,import-outside-toplevel,cyclic-import
 
 [TYPECHECK]
 # ignore kerberos module

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,18 @@ matrix:
       - python: 3.6
         env: TOX_ENV=py36-unit-tests
 
+      - python: 3.7
+        env: TOX_ENV=py37-static-analysis
+
+      - python: 3.7
+        env: TOX_ENV=py37-unit-tests
+
+      - python: 3.8
+        env: TOX_ENV=py38-static-analysis
+
+      - python: 3.8
+        env: TOX_ENV=py38-unit-tests
+
       # For type-check, we need Python 3 to power `mypy`. It's going to check types for both
       # Python 3 *and* 2, therefore it's perfectly fine to run it just once.
       - python: 3.6

--- a/gluetool/action.py
+++ b/gluetool/action.py
@@ -94,7 +94,6 @@ class Tracer(object):
     :param str reporting_host: address to which tracer should submit traces.
     :param int reporting_port: port to which tracer should submit tracers.
     """
-
     # pylint: disable=too-few-public-methods
 
     TRACER = None  # type: Optional[TracingClientType]
@@ -115,6 +114,7 @@ class Tracer(object):
             reporting_host = os.getenv(TRACING_REPORTING_HOST_ENVVAR, default=DEFAULT_TRACING_REPORTING_HOST)
 
         if not reporting_port:
+            # pylint: disable=bad-option-value,invalid-envvar-default
             reporting_port = int(os.getenv(TRACING_REPORTING_PORT_ENVVAR, default=DEFAULT_TRACING_REPORTING_PORT))
 
         config = tracing_client.Config(
@@ -159,6 +159,7 @@ class Tracer(object):
         from .utils import wait
 
         if not flush_timeout:
+            # pylint: disable=bad-option-value,invalid-envvar-default
             flush_timeout = int(os.getenv(TRACING_FLUSH_TIMEOUT_ENVVAR, default=DEFAULT_TRACING_FLUSH_TIMEOUT))
 
         # yield to IOLoop to flush the spans - https://github.com/jaegertracing/jaeger-client-python/issues/50

--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -312,8 +312,7 @@ def retry(*args):
             except args as e:
                 if isinstance(e, GlueError):
                     raise GlueRetryError(e.value)  # type: ignore
-                else:
-                    raise GlueRetryError(e)
+                raise GlueRetryError(e)
         return func_wrapper
     return wrap
 
@@ -696,6 +695,7 @@ class Pipeline(LoggerMixin, object):
             # The failure would then be propagated to `run()` method and it would represent the cause
             # that killed the pipeline.
 
+            # pylint: disable=bad-continuation
             with Action(
                 'executing module',
                 parent=self.action,
@@ -745,6 +745,7 @@ class Pipeline(LoggerMixin, object):
 
             # We get either `None` or a failure if an exception was raised by `destroy`. If it's a failure,
             # we can log it with a bit more context.
+            # pylint: disable=bad-continuation
             with Action(
                 'destroying module',
                 parent=self.action,
@@ -1553,6 +1554,7 @@ class Module(Configurable):
             eval_context_help(self)
         ]
 
+        # pylint: disable=not-callable
         self._parse_args(args,
                          usage='{} [options]'.format(Colors.style(self.unique_name, fg='cyan')),
                          description=docstring_to_help(self.__doc__ or ''),

--- a/gluetool/log.py
+++ b/gluetool/log.py
@@ -72,9 +72,9 @@ ExceptionInfoType = Union[
 LoggingFunctionType = Callable[
     [
         Arg(str),
-        DefaultNamedArg(ExceptionInfoType, 'exc_info'),
-        DefaultNamedArg(Dict[str, Any], 'extra'),
-        DefaultNamedArg(bool, 'sentry')
+        DefaultNamedArg(ExceptionInfoType, 'exc_info'),  # noqa: F821
+        DefaultNamedArg(Dict[str, Any], 'extra'),  # noqa: F821
+        DefaultNamedArg(bool, 'sentry')  # noqa: F821
     ],
     None
 ]
@@ -796,6 +796,7 @@ class LoggingFormatter(logging.Formatter):
     }
 
     #: Colorizers assigned to loglevels
+    # pylint: disable=not-callable
     _level_color = {
         logging.INFO: lambda text: Colors.style(text, fg='green'),
         logging.WARNING: lambda text: Colors.style(text, fg='yellow'),

--- a/gluetool/pylint/__init__.py
+++ b/gluetool/pylint/__init__.py
@@ -37,6 +37,7 @@ class OptionsGatherer(object):
     def walk(cls, node):
         gatherer = cls()
 
+        # pylint: disable=no-member
         walker = pylint.utils.PyLintASTWalker(None)
         walker.add_checker(gatherer)
         walker.walk(node)

--- a/gluetool/result.py
+++ b/gluetool/result.py
@@ -12,8 +12,10 @@ from typing import cast, Any, Generic, Optional, TypeVar, Union  # noqa
 #
 
 # T represents the type of valid value...
+# pylint: disable=invalid-name
 T = TypeVar("T")
 # ... and E represents type of the error description.
+# pylint: disable=invalid-name
 E = TypeVar("E")
 
 
@@ -49,10 +51,9 @@ class Result(Generic[T, E]):
         # type: (Any) -> bool
         # pylint: disable=protected-access
 
+        # pylint: disable=line-too-long
         return bool(
-            self.__class__ == other.__class__ and
-            self.is_ok == cast(Result[T, E], other).is_ok and
-            self._value == other._value
+            self.__class__ == other.__class__ and self.is_ok == cast(Result[T, E], other).is_ok and self._value == other._value  # Ignore: PEP8Bear
         )
 
     def __ne__(self, other):

--- a/gluetool/tests/__init__.py
+++ b/gluetool/tests/__init__.py
@@ -1,6 +1,5 @@
 # pylint: disable=blacklisted-name
 
-# pylint: disable=relative-import
 import json
 
 import ruamel.yaml

--- a/gluetool/tests/test_log_exception.py
+++ b/gluetool/tests/test_log_exception.py
@@ -20,7 +20,7 @@ gluetool.glue.GlueError: Foo failed
 
     Local variables:
         exc = Foo failed
-        excinfo = \(<class 'gluetool\.glue\.GlueError'>, GlueError\('Foo failed',\), <traceback object at 0x[0-9a-f]+>\)
+        excinfo = \(<class 'gluetool\.glue\.GlueError'>, GlueError\('Foo failed',?\), <traceback object at 0x[0-9a-f]+>\)
 
   File "{{ FILE}}", line 81, in foo
     raise gluetool.GlueError\('Foo failed'\)

--- a/gluetool/tests/test_render_template.py
+++ b/gluetool/tests/test_render_template.py
@@ -24,7 +24,10 @@ def test_render(template):
 
 
 def test_unexpected_template_type():
-    with pytest.raises(gluetool.GlueError, message="Unhandled template type <type 'int'>"):
+    with pytest.raises(
+        gluetool.GlueError,
+        match="Cannot render template: Unhandled template type <(type|class) 'int'>"
+    ):
         render_template(17)
 
 

--- a/gluetool/utils.py
+++ b/gluetool/utils.py
@@ -29,8 +29,6 @@ import six
 from six import PY2, ensure_str, iteritems, iterkeys
 from six.moves import http_client, urllib
 
-# Don't know why pylint reports "Relative import 'ruamel.yaml', should be 'gluetool.ruamel.yaml'" :(
-# pylint: disable=relative-import
 import ruamel.yaml
 
 from .glue import GlueError, SoftGlueError, GlueCommandError
@@ -49,6 +47,7 @@ if TYPE_CHECKING:
 
 
 # Type variable used in generic types
+# pylint: disable=invalid-name
 T = TypeVar('T')
 
 
@@ -507,10 +506,10 @@ class Command(LoggerMixin, object):
             return self.executable + self.options
 
         # escape apostrophes in strings and adds them around strings with space
+        # pylint: disable=line-too-long
         return [('"{}"'.format(option.replace('"', r'\"')) if ' ' in option and not
                  (
-                     (option.startswith('"') and option.endswith('"')) or
-                     (option.startswith("'") and option.endswith("'")))
+                     (option.startswith('"') and option.endswith('"')) or (option.startswith("'") and option.endswith("'")))  # Ignore PEP8Bear
                  else option) for option in self.executable + self.options]
 
     def _communicate_batch(self):

--- a/gluetool_modules/dep_list.py
+++ b/gluetool_modules/dep_list.py
@@ -109,7 +109,7 @@ class ModuleInfoGroup(object):
                 if not relate(Version(item.equal), Version(version)):
                     raise gluetool.GlueError("Cannot find common version for package '{}'".format(item.pkg))
             return '{}=={}'.format(item.pkg, item.equal)
-        elif item.upper and item.lower:
+        if item.upper and item.lower:
             lower_operator, lower_version = item.lower
             upper_operator, upper_version = item.upper
             relate = self.ops_map[lower_operator]
@@ -119,10 +119,10 @@ class ModuleInfoGroup(object):
             if not relate(Version(lower_version), Version(upper_version)):
                 raise gluetool.GlueError("Cannot find common version for package '{}'".format(item.pkg))
             return '{}{}{},{}{}'.format(item.pkg, lower_operator, lower_version, upper_operator, upper_version)
-        elif item.upper:
+        if item.upper:
             upper_operator, upper_version = item.upper
             return '{}{}{}'.format(item.pkg, upper_operator, upper_version)
-        elif item.lower:
+        if item.lower:
             lower_operator, lower_version = item.lower
             return '{}{}{}'.format(item.pkg, lower_operator, lower_version)
 

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,7 @@ if __name__ == '__main__':
               'raven==6.9.0',
               'requests==2.19.1',
               'requests-toolbelt==0.8.0',
-              # since 0.15.52, it returns ordereddict instead of pure dicts, making format_dict unhappy
-              'ruamel.yaml==0.15.51',
-              # newer versions bring way too many incompabilities, needs deeper inspection
-              # 'ruamel.yaml==0.15.34',
+              'ruamel.yaml==0.16.12',
               'six==1.12.0',
               'Sphinx==1.5.2',
               'sphinx-rtd-theme==0.4.1',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,22 @@
 # And these are the actual test requirements...
 codecov==2.0.15
-flake8==3.4.1
+flake8==3.8.3
 hypothesis==4.57.1
 isort==4.3.21
-pylint==1.9.2
+pylint==1.9.5; python_version == "2.7"
+pylint==2.5.3; python_version == "3.6"
+pylint==2.5.3; python_version == "3.7"
+pylint==2.5.3; python_version == "3.8"
 mock==2.0.0
-pytest-pylint==0.7.1
-pytest-flake8==0.8.1
+pytest-pylint==0.14.1; python_version == "2.7"
+pytest-pylint==0.16.1; python_version == "3.6"
+pytest-pylint==0.16.1; python_version == "3.7"
+pytest-pylint==0.16.1; python_version == "3.8"
+pytest-flake8==1.0.6
 pytest-cov==2.5.1
 pytest-catchlog==1.2.2
 pytest-mock==1.6.3
-pytest==3.2.3
+pytest==3.5.1; python_version == "2.7"
+pytest==5.4.3; python_version == "3.6"
+pytest==5.4.3; python_version == "3.7"
+pytest==5.4.3; python_version == "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-{static-analysis,unit-tests,codecov},type-check
+envlist = {py27,py36,py37,py38}-{static-analysis,unit-tests,codecov},type-check
 
 [testenv]
 # Tox should set correct Python version given the environment. let's trust it knows how.
@@ -18,6 +18,8 @@ envlist = {py27,py36}-{static-analysis,unit-tests,codecov},type-check
 envdir =
   py27: {toxinidir}/.tox/py27
   py36: {toxinidir}/.tox/py36
+  py37: {toxinidir}/.tox/py37
+  py38: {toxinidir}/.tox/py38
 
 # Don't spoil our nice virtualenvs with system packages
 sitepackages = False


### PR DESCRIPTION
To support these we need to do some major upgrades of test tools
and ruamel.yaml.

I was able to fix all tests, most things were fixed for new flake8, please review carefully, some things are not exactly clear to me and might be problematic.

Trying to run `gluetool-modules` tests against it.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>