### PR TITLE
Drop verbose logging during eval context gathering

### DIFF
--- a/gluetool/glue.py
+++ b/gluetool/glue.py
@@ -2059,7 +2059,6 @@ class Glue(Configurable):
         """
 
         stack = inspect.stack()
-        log_dict(self.verbose, 'stack', stack)
 
         # When being called as a regular shared function, the call stack layout should be
         # as follows:
@@ -2110,8 +2109,6 @@ class Glue(Configurable):
         for pipeline in self.pipelines:
             for module in pipeline.modules:
                 context.update(module.eval_context)
-
-        log_dict(self.verbose, 'eval context', context)
 
         return context
 

--- a/gluetool/tests/test_eval_context.py
+++ b/gluetool/tests/test_eval_context.py
@@ -39,5 +39,5 @@ def test_module_via_glue(module, log):
     assert 'MODULE' in eval_context
     assert eval_context['MODULE'] is None
 
-    assert log.records[-3].message == 'Cannot infer calling module of eval_context'
-    assert log.records[-3].levelno == logging.WARNING
+    assert log.records[-1].message == 'Cannot infer calling module of eval_context'
+    assert log.records[-1].levelno == logging.WARNING


### PR DESCRIPTION
Proved to be not needed, the feature works reliably, and context users often log the context before the use.