### PR TITLE
gluetool/tool: print exception name if message empty

### DIFF
--- a/gluetool/tool.py
+++ b/gluetool/tool.py
@@ -224,11 +224,13 @@ class Gluetool(object):
         if failure.module:
             msg = "Pipeline reported an exception in module '{}': {}".format(
                 failure.module.unique_name,
-                failure.exc_info[1]
+                str(failure.exc_info[1]) or repr(failure.exc_info[1])
             )
 
         else:
-            msg = "Pipeline reported an exception: {}".format(failure.exc_info[1])
+            msg = "Pipeline reported an exception: {}".format(
+                str(failure.exc_info[1]) or repr(failure.exc_info[1])
+            )
 
         logger.error(msg, exc_info=failure.exc_info)
 


### PR DESCRIPTION
In some cases, like KeyboardInterrupt, this can come
handy:

before: `[11:43:15] [E] Pipeline reported an exception:`
after: `[11:43:15] [E] Pipeline reported an exception: KeyboardInterrupt()`

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>