### PR TITLE
Adds map/map_error helpers to Result objects

### DIFF
--- a/gluetool/tests/test_result.py
+++ b/gluetool/tests/test_result.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import MagicMock
 
 import gluetool
 from gluetool.result import Result, Ok, Error
@@ -101,3 +102,31 @@ def test_unwrap_or():
     assert o.unwrap_or('default value') == 'foo'
     assert n.unwrap_or('default value') == 'default value'
 
+
+def test_map():
+    o = Ok('foo')
+
+    mock_on_error = MagicMock()
+
+    n = o \
+        .map(lambda s: Ok(s + 'bar')) \
+        .map(lambda s: Ok(s + 'baz')) \
+        .map_error(mock_on_error)
+
+    assert n.is_ok
+    assert n.unwrap() == 'foobarbaz'
+    mock_on_error.assert_not_called()
+
+
+def test_map_error():
+    o = Error('foo')
+
+    mock_on_ok = MagicMock()
+
+    n = o \
+        .map_error(lambda s: Error(s + 'bar')) \
+        .map(mock_on_ok)
+
+    assert n.is_error
+    assert n.unwrap_error() == 'foobar'
+    mock_on_ok.assert_not_called()


### PR DESCRIPTION
Following spaghetti code:

```python
r1 = foo()

if r1.is_error:
  return Error(r1.unwrap_error())

r2 = bar(r1.unwrap())

if r2.is_error:
  return Error(r2.unwrap_error())

return r2.unwrap()
```

would become this:

```python
return foo().map(lambda unwrapped_r1_value: bar(unwrapped_r1_value))
```

`map()` calls given function passing it the uinwrapped value. If the
result is invalid, the function is not called and error is propagated.
`map_error()` works in the same way, but with errors, not touching the
valid results.

Together, we can chain the calls and get rid of the pesky `if
foo.is_error: return Error(foo.unwrap_error())`.